### PR TITLE
Leverage Server-Timing header for automatic backend correlation

### DIFF
--- a/lib/serverTiming.js
+++ b/lib/serverTiming.js
@@ -1,0 +1,30 @@
+// @flow
+
+import {performance, isResourceTimingAvailable} from './performance';
+import {info} from './debug';
+import vars from './vars';
+
+export function getPageLoadBackendTraceId() {
+  if (!isResourceTimingAvailable) {
+    return null;
+  }
+
+  const entries = performance.getEntriesByType('navigation');
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+
+    if (entry['serverTiming'] != null) {
+      for (let j = 0; j < entry['serverTiming'].length; j++) {
+        const serverTiming = entry['serverTiming'][j];
+        if (serverTiming['name'] === vars.serverTimingBackendTraceIdEntryName) {
+          if (DEBUG) {
+            info('Found page load backend trace ID %s in Server-Timing header.', serverTiming['description']);
+          }
+          return serverTiming['description'];
+        }
+      }
+    }
+  }
+
+  return null;
+}

--- a/lib/states/init.js
+++ b/lib/states/init.js
@@ -3,6 +3,7 @@
 import {instrumentXMLHttpRequest} from '../hooks/XMLHttpRequest';
 import {hookIntoGlobalErrorEvent} from '../hooks/unhandledError';
 import type {State, EndSpaPageTransitionOpts} from '../types';
+import {getPageLoadBackendTraceId} from '../serverTiming';
 import {processCommand} from '../commands';
 import {error, warn} from '../debug';
 import {transitionTo} from '../fsm';
@@ -43,6 +44,8 @@ const state: State = {
 
     processCommands(globalObject.q);
 
+    // prefer the backend trace ID which was explicitly set
+    vars.pageLoadBackendTraceId = vars.pageLoadBackendTraceId || getPageLoadBackendTraceId();
     vars.initializerExecutionTimestamp = globalObject['l'];
 
     addCommandAfterInitializationSupport();

--- a/lib/vars.js
+++ b/lib/vars.js
@@ -24,6 +24,12 @@ const defaultVars: {
   // eum('traceId', '123');
   pageLoadBackendTraceId: ?string,
 
+  // Name of the server timing entry under which the backend trace
+  // ID can be found. Expects a server timing entry in the following
+  // format.
+  // PerformanceServerTiming {name: "intid", duration: 0, description: "1f27caa3493aeb"}
+  serverTimingBackendTraceIdEntryName: string,
+
   // All timestamps which are part of beacons will be adjusted
   // using this timestamp before transmission to save some bytes.
   // So what we are doing is:
@@ -147,6 +153,7 @@ const defaultVars: {
   nameOfLongGlobal: 'EumObject',
   pageLoadTraceId: generateUniqueId(),
   pageLoadBackendTraceId: null,
+  serverTimingBackendTraceIdEntryName: 'intid',
   referenceTimestamp: now(),
   highResTimestampReference: performance && performance.now ? performance.now() : 0,
   initializerExecutionTimestamp: now(),

--- a/protractor.config.js
+++ b/protractor.config.js
@@ -7,6 +7,7 @@ if (process.env.TRAVIS) {
     sauceKey: process.env.SAUCE_ACCESS_KEY,
     sauceBuild: process.env.TRAVIS_JOB_NUMBER,
     multiCapabilities: [
+      newSaucelabsCapability('chrome', '65.0', 'OS X 10.11'),
       newSaucelabsCapability('chrome', '54.0', 'OS X 10.11'),
       newSaucelabsCapability('chrome', '48.0', 'Windows 10'),
       newSaucelabsCapability('firefox', '45.0', 'Linux'),

--- a/test/e2e/00_pageLoad.spec.js
+++ b/test/e2e/00_pageLoad.spec.js
@@ -41,7 +41,6 @@ describe('00_pageLoad', () => {
             cexpect(beacon.d.length).to.be.below(6);
             cexpect(beacon.ty).to.equal('pl');
             cexpect(beacon.k).to.equal(undefined);
-            cexpect(beacon.bt).to.equal(undefined);
             cexpect(beacon.p).to.equal(undefined);
             cexpect(beacon.u).to.equal(getE2ETestBaseUrl('00_pageLoad'));
           });

--- a/test/e2e/04_serverTiming.html
+++ b/test/e2e/04_serverTiming.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>server timing test</title>
+</head>
+<body>
+  <script src="/e2e/initializer.js"></script>
+</body>
+</html>

--- a/test/e2e/04_serverTiming.spec.js
+++ b/test/e2e/04_serverTiming.spec.js
@@ -1,0 +1,35 @@
+const {registerTestServerHooks, getE2ETestBaseUrl, getBeacons} = require('../server/controls');
+const {registerBaseHooks, getCapabilities} = require('./base');
+const util = require('../util');
+
+const cexpect = require('chai').expect;
+
+describe('04_serverTiming', () => {
+  registerTestServerHooks();
+  registerBaseHooks();
+
+  beforeEach(() => {
+    browser.get(getE2ETestBaseUrl('04_serverTiming'));
+  });
+
+  it('must read backend trace ID when available from server timing header', () => {
+    return getCapabilities().then(capabilities => {
+      if (!hasServerTimingSupport(capabilities)) {
+        return;
+      }
+
+      return util.retry(() => {
+        return getBeacons()
+          .then(beacons => {
+            cexpect(beacons).to.have.lengthOf(1);
+            cexpect(beacons[0].bt).to.equal('aFakeBackendTraceIdForTests');
+          });
+      });
+    });
+  });
+
+  function hasServerTimingSupport(capabilities) {
+    const version = Number(capabilities.version);
+    return capabilities.browserName === 'chrome' && (capabilities.version == null || version >= 65);
+  }
+});

--- a/test/e2e/initializer.js
+++ b/test/e2e/initializer.js
@@ -15,6 +15,10 @@
   eum('reportingUrl', '/beacon');
   eum('ignoreUrls', [/.*pleaseIgnoreThis.*/]);
 
+  if (window.location.href.indexOf('debug=true') !== -1) {
+    eum('autoClearResourceTimings', false);
+  }
+
   if (window.onEumLoad) {
     window.onEumLoad(eum);
   }

--- a/test/server/server.js
+++ b/test/server/server.js
@@ -10,6 +10,11 @@ app.use((req, res, next) => {
   next();
 });
 
+app.use((req, res, next) => {
+  res.set('Server-Timing', 'intid;desc=aFakeBackendTraceIdForTests');
+  next();
+});
+
 app.use('/target', express.static(path.join(__dirname, '..', '..', 'target')));
 app.use('/e2e', express.static(path.join(__dirname, '..', 'e2e')));
 


### PR DESCRIPTION
Read the backend trace ID from the server timing header, which is
available via the performance interface. This makes manual definition of
the backend trace ID obsolete in bleeding edge browsers.