### PR TITLE
Fix error in fetch instrumentation for ignored requests

### DIFF
--- a/lib/hooks/Fetch.js
+++ b/lib/hooks/Fetch.js
@@ -32,7 +32,7 @@ export function instrumentFetch() {
           'Not generating XHR beacon for fetch call because it is to be ignored according to user configuration. URL: ' + url
         );
       }
-      return originalFetch(input, init);
+      return originalFetch(request);
     }
 
     // $FlowFixMe: Some properties deliberately left our for js file size reasons.

--- a/test/e2e/05_fetch/fetch.spec.js
+++ b/test/e2e/05_fetch/fetch.spec.js
@@ -231,7 +231,7 @@ describe('05_fetch', () => {
 
               cexpect(result).to.equal(ajaxRequest.response);
 
-              cexpect(ajaxRequests.length).to.equal(2);
+              cexpect(ajaxRequests.length).to.equal(3);
               cexpect(beacons.length).to.equal(2);
             });
         })

--- a/test/e2e/05_fetch/ignoredFetch.html
+++ b/test/e2e/05_fetch/ignoredFetch.html
@@ -15,7 +15,14 @@
     $(window).on('load', function() {
       setTimeout(function() {
         if (self.fetch) {
-          fetch('/ajax' + '?pleaseIgnoreThis?cacheBust=' + (new Date()).getTime())
+          fetch('/ajax?pleaseIgnoreThis?cacheBust=' + (new Date()).getTime())
+          .then(function() {
+            var req = new Request('/ajax?pleaseIgnoreThis&cacheBust=' + (new Date()).getTime(), {
+              method: 'POST',
+              body: new Blob([JSON.stringify({'foo': 'bar'}, null, 2)], {type : 'application/json'})
+            });
+            return fetch(req);
+          })
           .then(function(response1) {
             return fetch('/ajax' + '?cacheBust=' + (new Date()).getTime())
           })
@@ -26,6 +33,7 @@
             $('#result').text(responseBody);
           })
           .catch(function(e) {
+            console.error(e);
             $('#result').text('error: ' + JSON.stringify(e));
           });
         } else {


### PR DESCRIPTION
Error:

```
Cannot construct a Request with a Request object that has already been used.
```

This error is caused when request objects are passed in. See producer.