### PR TITLE
Prepare migration to changed backend correlation

### DIFF
--- a/lib/hooks/Fetch.js
+++ b/lib/hooks/Fetch.js
@@ -2,11 +2,11 @@
 
 import {createExcessiveUsageIdentifier} from '../excessiveUsageIdentification';
 import type {ObserveResourcePerformanceResult} from '../performanceObserver';
+import {addResourceTiming, addCorrelationHttpHeaders} from './xhrHelpers';
 import {addCommonBeaconProperties} from '../commonBeaconProperties';
 import {observeResourcePerformance} from '../performanceObserver';
 import {isWhitelistedOrigin} from '../whitelistedOrigins';
 import {sendBeacon} from '../transmission/index';
-import {addResourceTiming} from './xhrHelpers';
 import {originalFetch, win} from '../browser';
 import {now, generateUniqueId} from '../util';
 import {normalizeUrl} from './normalizeUrl';
@@ -80,9 +80,7 @@ export function instrumentFetch() {
     beacon['bc'] = setBackendCorrelationHeaders ? 1 : 0;
 
     if (setBackendCorrelationHeaders) {
-      request.headers.append('X-INSTANA-T', spanAndTraceId);
-      request.headers.append('X-INSTANA-S', spanAndTraceId);
-      request.headers.append('X-INSTANA-L', '1');
+      addCorrelationHttpHeaders(request.headers.append, request.headers, spanAndTraceId);
     }
 
     const performanceObserver = observeResourcePerformance({

--- a/lib/hooks/XMLHttpRequest.js
+++ b/lib/hooks/XMLHttpRequest.js
@@ -2,11 +2,11 @@
 
 import {createExcessiveUsageIdentifier} from '../excessiveUsageIdentification';
 import type {ObserveResourcePerformanceResult} from '../performanceObserver';
+import {addResourceTiming, addCorrelationHttpHeaders} from './xhrHelpers';
 import {addCommonBeaconProperties} from '../commonBeaconProperties';
 import {observeResourcePerformance} from '../performanceObserver';
 import {isWhitelistedOrigin} from '../whitelistedOrigins';
 import {sendBeacon} from '../transmission/index';
-import {addResourceTiming} from './xhrHelpers';
 import {now, generateUniqueId} from '../util';
 import {normalizeUrl} from './normalizeUrl';
 import {isUrlIgnored} from '../ignoreRules';
@@ -248,9 +248,7 @@ export function instrumentXMLHttpRequest() {
     }
 
     if (state.setBackendCorrelationHeaders) {
-      originalSetRequestHeader.call(this, 'X-INSTANA-T', state.spanAndTraceId);
-      originalSetRequestHeader.call(this, 'X-INSTANA-S', state.spanAndTraceId);
-      originalSetRequestHeader.call(this, 'X-INSTANA-L', '1');
+      addCorrelationHttpHeaders(originalSetRequestHeader, this, state.spanAndTraceId);
     }
 
     state.beacon['ts'] = now() - vars.referenceTimestamp;

--- a/lib/hooks/xhrHelpers.js
+++ b/lib/hooks/xhrHelpers.js
@@ -38,3 +38,9 @@ function getTimingValue(timing: any) {
   }
   return undefined;
 }
+
+export function addCorrelationHttpHeaders(fn, ctx, traceId) {
+  fn.call(ctx, 'X-INSTANA-T', traceId);
+  fn.call(ctx, 'X-INSTANA-S', traceId);
+  fn.call(ctx, 'X-INSTANA-L', '1,correlationType=web;correlationId=' + traceId);
+}

--- a/test/e2e/01_xhr/xhr.spec.js
+++ b/test/e2e/01_xhr/xhr.spec.js
@@ -51,7 +51,7 @@ describe('xhr', () => {
                 cexpect(ajaxRequest.url).to.match(/^\/ajax\?cacheBust=\d+$/);
                 cexpect(ajaxRequest.headers['x-instana-t']).to.equal(ajaxBeacon.t);
                 cexpect(ajaxRequest.headers['x-instana-s']).to.equal(ajaxBeacon.s);
-                cexpect(ajaxRequest.headers['x-instana-l']).to.equal('1');
+                cexpect(ajaxRequest.headers['x-instana-l']).to.equal('1,correlationType=web;correlationId=' + ajaxBeacon.t);
               });
 
               cexpect(result).to.equal(ajaxRequest.response);
@@ -108,7 +108,7 @@ describe('xhr', () => {
                 cexpect(ajaxRequest.url).to.match(/^\/ajax\?cacheBust=\d+$/);
                 cexpect(ajaxRequest.headers['x-instana-t']).to.equal(ajaxBeacon.t);
                 cexpect(ajaxRequest.headers['x-instana-s']).to.equal(ajaxBeacon.s);
-                cexpect(ajaxRequest.headers['x-instana-l']).to.equal('1');
+                cexpect(ajaxRequest.headers['x-instana-l']).to.equal('1,correlationType=web;correlationId=' + ajaxBeacon.t);
               });
 
               cexpect(result).to.equal(ajaxRequest.response);
@@ -148,7 +148,7 @@ describe('xhr', () => {
                 cexpect(ajaxRequest.url).to.match(/^\/ajax\?cacheBust=\d+$/);
                 cexpect(ajaxRequest.headers['x-instana-t']).to.equal(ajaxBeacon.t);
                 cexpect(ajaxRequest.headers['x-instana-s']).to.equal(ajaxBeacon.s);
-                cexpect(ajaxRequest.headers['x-instana-l']).to.equal('1');
+                cexpect(ajaxRequest.headers['x-instana-l']).to.equal('1,correlationType=web;correlationId=' + ajaxBeacon.t);
               });
 
               cexpect(result).to.equal(ajaxRequest.response);

--- a/test/e2e/05_fetch/fetch.spec.js
+++ b/test/e2e/05_fetch/fetch.spec.js
@@ -52,7 +52,7 @@ describe('05_fetch', () => {
                 cexpect(ajaxRequest.url).to.match(/^\/ajax\?cacheBust=\d+$/);
                 cexpect(ajaxRequest.headers['x-instana-t']).to.equal(ajaxBeacon.t);
                 cexpect(ajaxRequest.headers['x-instana-s']).to.equal(ajaxBeacon.s);
-                cexpect(ajaxRequest.headers['x-instana-l']).to.equal('1');
+                cexpect(ajaxRequest.headers['x-instana-l']).to.equal('1,correlationType=web;correlationId=' + ajaxBeacon.t);
                 cexpect(ajaxRequest.headers['from']).to.equal('stan@instana.com');
               });
 
@@ -103,7 +103,7 @@ describe('05_fetch', () => {
                 cexpect(ajaxRequest.url).to.match(/^\/ajax\?cacheBust=\d+$/);
                 cexpect(ajaxRequest.headers['x-instana-t']).to.equal(ajaxBeacon.t);
                 cexpect(ajaxRequest.headers['x-instana-s']).to.equal(ajaxBeacon.s);
-                cexpect(ajaxRequest.headers['x-instana-l']).to.equal('1');
+                cexpect(ajaxRequest.headers['x-instana-l']).to.equal('1,correlationType=web;correlationId=' + ajaxBeacon.t);
                 cexpect(ajaxRequest.headers['from']).to.equal('stan@instana.com');
               });
 
@@ -154,7 +154,7 @@ describe('05_fetch', () => {
                 cexpect(ajaxRequest.url).to.match(/^\/ajax\?cacheBust=\d+$/);
                 cexpect(ajaxRequest.headers['x-instana-t']).to.equal(ajaxBeacon.t);
                 cexpect(ajaxRequest.headers['x-instana-s']).to.equal(ajaxBeacon.s);
-                cexpect(ajaxRequest.headers['x-instana-l']).to.equal('1');
+                cexpect(ajaxRequest.headers['x-instana-l']).to.equal('1,correlationType=web;correlationId=' + ajaxBeacon.t);
                 cexpect(ajaxRequest.headers['from']).to.equal('stan@instana.com');
               });
 
@@ -196,7 +196,7 @@ describe('05_fetch', () => {
                 cexpect(ajaxRequest.url).to.match(/^\/ajax\?cacheBust=\d+$/);
                 cexpect(ajaxRequest.headers['x-instana-t']).to.equal(ajaxBeacon.t);
                 cexpect(ajaxRequest.headers['x-instana-s']).to.equal(ajaxBeacon.s);
-                cexpect(ajaxRequest.headers['x-instana-l']).to.equal('1');
+                cexpect(ajaxRequest.headers['x-instana-l']).to.equal('1,correlationType=web;correlationId=' + ajaxBeacon.t);
               });
 
               cexpect(result).to.equal(ajaxRequest.response);
@@ -340,7 +340,7 @@ describe('05_fetch', () => {
                 cexpect(ajaxRequest.url).to.match(/^\/ajax\?cacheBust=\d+$/);
                 cexpect(ajaxRequest.headers['x-instana-t']).to.equal(ajaxBeacon.t);
                 cexpect(ajaxRequest.headers['x-instana-s']).to.equal(ajaxBeacon.s);
-                cexpect(ajaxRequest.headers['x-instana-l']).to.equal('1');
+                cexpect(ajaxRequest.headers['x-instana-l']).to.equal('1,correlationType=web;correlationId=' + ajaxBeacon.t);
                 cexpect(ajaxRequest.headers['from']).to.equal('stan@instana.com');
               });
 


### PR DESCRIPTION
# Why

In order to have a weaker reference between tracing and website
monitoring on the backend side.

# What

Extend the `X-INSTANA-L` header.