### PR TITLE
Add Zone.js awareness

### DIFF
--- a/lib/events/onLoad.js
+++ b/lib/events/onLoad.js
@@ -1,9 +1,10 @@
 // @flow
 
 import {addEventListener, now} from '../util';
+import {setTimeout} from '../timers';
 import type {Event} from '../types';
-import {win} from '../browser';
 import {emit} from '../eventBus';
+import {win} from '../browser';
 
 const event: Event = {
   name: 'e:onLoad',

--- a/lib/excessiveUsageIdentification.js
+++ b/lib/excessiveUsageIdentification.js
@@ -1,5 +1,7 @@
 // @flow
 
+import {setInterval} from './timers';
+
 export function createExcessiveUsageIdentifier(opts: {
   maxCalls?: number,
   maxCallsPerTenMinutes: number,

--- a/lib/hooks/timers.js
+++ b/lib/hooks/timers.js
@@ -1,11 +1,19 @@
 // @flow
 
 import {reportError, ignoreNextOnErrorEvent} from './unhandledError';
+import {isRunningZoneJs} from '../timers';
 import {win} from '../browser';
+import {warn} from '../debug';
 import vars from '../vars';
 
 export function wrapTimers() {
   if (vars.wrapTimers) {
+    if (isRunningZoneJs) {
+      if (DEBUG) {
+        warn('We discovered a usage of Zone.js. In order to avoid any incompatibility issues timer wrapping is not going to be enabled.');
+      }
+      return;
+    }
     wrapTimer('setTimeout');
     wrapTimer('setInterval');
   }

--- a/lib/hooks/unhandledError.js
+++ b/lib/hooks/unhandledError.js
@@ -3,6 +3,7 @@
 import {addCommonBeaconProperties, addMetaDataToBeacon} from '../commonBeaconProperties';
 import type {UnhandledErrorBeacon, ReportErrorOpts, Meta} from '../types';
 import {isErrorMessageIgnored} from '../ignoreRules';
+import {setTimeout, clearTimeout} from '../timers';
 import {sendBeacon} from '../transmission/index';
 import {now, generateUniqueId} from '../util';
 import {getActiveTraceId} from '../fsm';

--- a/lib/performanceObserver.js
+++ b/lib/performanceObserver.js
@@ -2,6 +2,7 @@
 
 import {performance, isPerformanceObserverAvailable} from './performance';
 import {noop, now, addEventListener, removeEventListener} from './util';
+import {setTimeout, clearTimeout} from './timers';
 import {doc, win} from './browser';
 
 const ONE_DAY_IN_MILLIS = 1000 * 60 * 60 * 24;

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -1,0 +1,75 @@
+import {warn, info} from './debug';
+import {win} from './browser';
+
+// This module contains wrappers around the standard timer API. These wrappers can be used to
+// ensure that execution of timers happens outside of any Angular specific zones. This in turn
+// means that this script will never disturb Angular's stabilization phase.
+// https://angular.io/api/core/ApplicationRef#isStable
+// Please note that it may sometimes be necessary to deliberately execute code inside of
+// Angular's Zones. Always take care to make a deliberate decision when to use and when not to
+// use these wrappers.
+
+// We take a copy of all globals to ensure that no other script will change them all of a sudden.
+// This ensures that when we register a timeout/interval on one global, that we will be able to
+// de-register it again in all cases.
+const globals = {
+  'setTimeout': win.setTimeout,
+  'clearTimeout': win.clearTimeout,
+  'setInterval': win.setInterval,
+  'clearInterval': win.clearInterval
+};
+
+// If the globals don't exist at execution time of this file, then we know that the globals stored
+// above are not wrapped by Zone.js. This in turn can mean better performance for Angular users.
+export const isRunningZoneJs = win['Zone'] != null &&
+  win['Zone']['root'] != null &&
+  typeof win['Zone']['root']['run'] === 'function';
+
+if (DEBUG && isRunningZoneJs) {
+  info('Discovered Zone.js globals. Will attempt to register all timers inside the root Zone.');
+}
+
+export function setTimeout() {
+  return executeGlobally.apply('setTimeout', arguments);
+}
+
+export function clearTimeout() {
+  return executeGlobally.apply('clearTimeout', arguments);
+}
+
+export function setInterval() {
+  return executeGlobally.apply('setInterval', arguments);
+}
+
+export function clearInterval() {
+  return executeGlobally.apply('clearInterval', arguments);
+}
+
+function executeGlobally() {
+  // We don't want to incur a performance penalty for all users just because some
+  // users are relying on zone.js. This API looks quite ridiculous, but it
+  // allows for concise and efficient code, e.g. arguments does not need to be
+  // translated into an array.
+  const globalFunctionName = this;
+
+  if (isRunningZoneJs) {
+    try {
+      // Incurr a performance overhead for Zone.js users that we just cannot avoid:
+      // Copy the arguments passed in here so that we can use them inside the root
+      // zone.
+      const args = Array.prototype.slice.apply(arguments);
+      return win['Zone']['root']['run'](globals[globalFunctionName], win, args);
+    } catch (e) {
+      if (DEBUG) {
+        warn('Failed to execute %s inside of zone (via Zone.js). Falling back to execution inside currently ' +
+          'active zone.', globalFunctionName, e);
+      }
+      // failure – maybe zone js not properly initialized? Fall back to execution
+      // outside of Zone.js as a last resort (outside of try/catch and if)
+    }
+  }
+
+  // Note: Explicitly passing win as 'this' even though we are getting the function from 'globals'
+  return globals[globalFunctionName].apply(win, arguments);
+}
+

--- a/lib/transmission/batched.js
+++ b/lib/transmission/batched.js
@@ -2,6 +2,7 @@
 
 import { doc, nav, win, XMLHttpRequest, sendBeacon as sendBeaconInternal } from '../browser';
 import { disableMonitoringForXMLHttpRequest } from '../hooks/xhrHelpers';
+import {setTimeout, clearTimeout} from '../timers';
 import { addEventListener } from '../util';
 import { encode } from './lineEncoding';
 import type { Beacon } from '../types';

--- a/test/e2e/05_fetch/fetchNoZoneImpact.html
+++ b/test/e2e/05_fetch/fetchNoZoneImpact.html
@@ -1,0 +1,45 @@
+<!doctype html>
+  <html>
+  <head>
+    <meta charset="UTF-8">
+    <title>fetch no zone impact test</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/zone.js/0.9.1/zone.min.js"></script>
+    <script src="/e2e/initializer.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.js"></script>
+  </head>
+  <body>
+    fetch after page load
+
+    <div id="result"></div>
+
+    <script>
+      $(window).on('load', function() {
+        window.tasksScheduled = 0;
+        window.testZone = Zone.current.fork({
+          name: 'testZone',
+          onScheduleTask: function(delegate, current, target, task) {
+            window.tasksScheduled++;
+            delegate.scheduleTask(target, task);
+          }
+        });
+
+        window.testZone.run(function() {
+          if (self.fetch) {
+            fetch('/ajax' + '?cacheBust=' + (new Date()).getTime(), {
+              headers: {
+                'From': 'stan@instana.com'
+              }
+            })
+            .catch(function(e) {
+              console.error('Fetch error', e);
+            });
+
+            $('#result').text(window.tasksScheduled);
+          } else {
+            $('#result').text('The Fetch API is not supported by this browser.');
+          }
+        });
+      });
+    </script>
+  </body>
+  </html>

--- a/test/unit/excessiveUsageIdentification.test.js
+++ b/test/unit/excessiveUsageIdentification.test.js
@@ -1,13 +1,15 @@
 import { expect } from 'chai';
 
-import { createExcessiveUsageIdentifier } from '../../lib/excessiveUsageIdentification';
-
 jest.useFakeTimers();
 
 describe('excessiveUsageIdentification', () => {
+  let createExcessiveUsageIdentifier;
   let isExcessiveUsage;
 
   beforeEach(() => {
+    jest.resetModules();
+    self.DEBUG = false;
+    createExcessiveUsageIdentifier = require('../../lib/excessiveUsageIdentification').createExcessiveUsageIdentifier;
     isExcessiveUsage = null;
   });
 

--- a/test/unit/performanceObserver.test.js
+++ b/test/unit/performanceObserver.test.js
@@ -1,11 +1,6 @@
 /* eslint-disable quotes */
 
-import sinon from 'sinon';
-
-jest.mock('../../lib/browser');
-jest.mock('../../lib/performance');
-
-describe.only('performanceObserver', () => {
+describe('performanceObserver', () => {
   let browserMock;
   let performanceMock;
   let observeResourcePerformance;
@@ -16,7 +11,16 @@ describe.only('performanceObserver', () => {
   let clock;
 
   beforeEach(() => {
-    clock = sinon.useFakeTimers();
+    self.DEBUG = false;
+    jest.resetModules();
+    clock = require('sinon').useFakeTimers();
+    jest.mock('../../lib/browser');
+    const {win} = require('../../lib/browser');
+    win.setTimeout = setTimeout;
+    win.clearTimeout = clearTimeout;
+    win.setInterval = setInterval;
+    win.clearInterval = clearInterval;
+    jest.mock('../../lib/performance');
     resourceMatcher = jest.fn();
     resourceMatcher.mockReturnValue(true);
     browserMock = require('../../lib/browser');

--- a/test/unit/transmission/batched.test.js
+++ b/test/unit/transmission/batched.test.js
@@ -23,6 +23,7 @@ describe('transmission/batched', () => {
   let sendBeacon;
 
   beforeEach(() => {
+    self.DEBUG = false;
     browserMock = require('../../../lib/browser');
     browserMock.reset();
     varsMock = require('../../../lib/vars').default;


### PR DESCRIPTION
# Why

Angular has [a concept](https://angular.io/api/core/ApplicationRef#isStable)
of an application being `stable`. This is an important concept of Angular
applications as it is used for testing purposes, the registration of custom
timers and more. Unfortunately `stable` is implemented via
[Zones](https://github.com/angular/angular/blob/master/packages/zone.js).
More specifically an Angular application is defined as stable when there are
no more pending tasks.

Weasel does register some timers, e.g. when making `XMLHttpRequest` or `fetch`
API calls. These timers in turn are blocking the Angular application from
becoming stable.

# What

Angular has its own zones that it uses to execute the stabilization checks.
Try to always avoid these zones by entering the root zone when running on
a website that is leveraging the Zone library. This in turn means that
any website employing a similar mechanism will:

 a) Not see our timers.
 b) Potentially run faster because no change identification logic is executed
    due to our timers.