### PR TITLE
localStorage is not truly optional

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -9,7 +9,15 @@ export const nav: any = navigator;
 export const encodeURIComponent: string => string = win.encodeURIComponent;
 export const XMLHttpRequest = win.XMLHttpRequest;
 export const originalFetch = win.fetch;
-export const localStorage: Storage = win.localStorage;
+export const localStorage: ?Storage = (function() {
+  try {
+    return win.localStorage;
+  } catch (e) {
+    // localStorage access is not permitted in certain security modes, e.g.
+    // when cookies are completely disabled in web browsers.
+    return null;
+  }
+})();
 
 /**
  * Leverage's browser behavior to load image sources. Exposed via this module

--- a/lib/localStorage.js
+++ b/lib/localStorage.js
@@ -8,13 +8,19 @@ export const isSupported =
   localStorage != null && typeof localStorage.getItem === 'function' && typeof localStorage.setItem === 'function';
 
 export function getItem(k: string): ?string {
-  return localStorage.getItem(k);
+  if (isSupported && localStorage) {
+    return localStorage.getItem(k);
+  }
 }
 
 export function setItem(k: string, v: string): void {
-  localStorage.setItem(k, v);
+  if (isSupported && localStorage) {
+    localStorage.setItem(k, v);
+  }
 }
 
 export function removeItem(k: string): void {
-  localStorage.removeItem(k);
+  if (isSupported && localStorage) {
+    localStorage.removeItem(k);
+  }
 }


### PR DESCRIPTION
Why
===

Web browsers throw a `SecurityError` already when accessing
`window.localStorage`. This in turn breaks Weasel completely.

What
====

Make `localStorage` even more optional.