### PR TITLE
Ignore data transmission requests

### DIFF
--- a/lib/ignoreRules.js
+++ b/lib/ignoreRules.js
@@ -6,7 +6,7 @@ import vars from './vars';
 const dataUrlPrefix = 'data:';
 const ignorePingsRegex = /.*\/ping(\/?$|\?.*)/i;
 
-export function isUrlIgnored(url: ?string|?number) {
+export function isUrlIgnored(url: ?string|?number): boolean {
   if (!url) {
     return true;
   }
@@ -26,6 +26,14 @@ export function isUrlIgnored(url: ?string|?number) {
   }
 
   if (vars.ignorePings && ignorePingsRegex.test(url)) {
+    return true;
+  }
+
+  // Disable monitoring of data transmission requests. The data transmission strategy already ensures
+  // that data transmission requests are not picked up internally. However we have seen some users
+  // leverage custom (broken) XMLHttpRequest instrumentations to implement application code which
+  // then break the detection of data transmission requests.
+  if (vars.reportingUrl && (url === vars.reportingUrl || url === vars.reportingUrl + '/')) {
     return true;
   }
 

--- a/test/unit/ignoreRules.test.js
+++ b/test/unit/ignoreRules.test.js
@@ -8,6 +8,7 @@ describe('ignoreRules', () => {
     vars.ignoreUrls = [];
     vars.ignorePings = true;
     vars.ignoreErrorMessages = [];
+    vars.reportingUrl = 'https://ingress.example.com';
   });
 
   describe('isUrlIgnored', () => {
@@ -46,6 +47,12 @@ describe('ignoreRules', () => {
 
     it('must ignore data URLs by default', () => {
       expect(isUrlIgnored('data:text/html,%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E')).to.equal(true);
+    });
+
+    it('must ignore data transmission requests', () => {
+      expect(isUrlIgnored(vars.reportingUrl)).to.equal(true);
+      expect(isUrlIgnored(vars.reportingUrl + '/')).to.equal(true);
+      expect(isUrlIgnored(vars.reportingUrl + '/eum.min.js')).to.equal(false);
     });
   });
 


### PR DESCRIPTION
# Why

Data transmission requests can currently be picked up by Weasel
when users have custom `XMLHttpRequest` instrumentation logic.

# What

Make the detection of data transmission requests more resilient.