### PR TITLE
Remove unload listener

### DIFF
--- a/lib/events/onLastChance.js
+++ b/lib/events/onLastChance.js
@@ -29,10 +29,6 @@ export function onLastChance(fn: Function) {
     }
   });
 
-  // Unload is needed to fix this bug:
-  // https://bugs.chromium.org/p/chromium/issues/detail?id=987409
-  addEventListener(win, 'unload', function() {});
-
   // According to the spec visibilitychange should be a replacement for
   // beforeunload, but the reality is different (as of 2019-04-17). Chrome will
   // close tabs without firing visibilitychange. beforeunload on the other hand


### PR DESCRIPTION
# Why

`unload` makes pages inelligible for bfcache optimizations. This
might be observed by our customers as part of newer Lighthouse
audits.

# What

Remove the `unload` event registration and rely on the other
existing events. This is in line with recent learnings of the
web-vitals lib.