### PR TITLE
sendBeacon calls can throw Errors

### DIFF
--- a/lib/transmission/batched.js
+++ b/lib/transmission/batched.js
@@ -6,6 +6,7 @@ import {onLastChance} from '../events/onLastChance';
 import {setTimeout, clearTimeout} from '../timers';
 import { encode } from './lineEncoding';
 import type { Beacon } from '../types';
+import { warn } from '../debug';
 import vars from '../vars';
 
 const maxBatchedBeacons = 15;
@@ -67,11 +68,29 @@ function transmit() {
     return;
   }
 
-  // This will transmit a text/plain;charset=UTF-8 content type. This may not be what we
-  // want, but changing the content type via the Blob constructor currently
-  // breaks for cross-origin requests.
-  // https://bugs.chromium.org/p/chromium/issues/detail?id=490015
-  const sendBeaconState = isSendBeaconApiSupported() && sendBeaconInternal(String(vars.reportingUrl), serializedBeacons);
+  let sendBeaconState = false;
+  if (isSendBeaconApiSupported()) {
+    try {
+      // This will transmit a text/plain;charset=UTF-8 content type. This may not be what we
+      // want, but changing the content type via the Blob constructor currently
+      // breaks for cross-origin requests.
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=490015
+      sendBeaconState = sendBeaconInternal(String(vars.reportingUrl), serializedBeacons);
+    } catch (e) {
+      // We have received reports that the navigator.sendBeacon API is failing in certain
+      // Edge 14.x versions. Unfortunately, we cannot reproduce this with our existing
+      // testing facilities. So we add a try/catch with logging and XMLHttpRequest
+      // as a fallback.
+      if (DEBUG) {
+        warn(
+          'navigator.sendBeacon has thrown an unexpected error. Will fall back to other transmission strategy.',
+          'navigator.sendBeacon parameters:',
+          String(vars.reportingUrl),
+          serializedBeacons
+        );
+      }
+    }
+  }
 
   // There are limits to the amount of data transmittable via the sendBeacon API.
   // If it doesn't work via the sendBeacon, try it via plain old AJAX APIs


### PR DESCRIPTION
# Why

We got reports from customers that the sendBeacon API fails in certain
Edge 14.X versions.

# What

Unfortunately, Saucelabs does not support the specific Edge versions in
questions. Consequently, we cannot reproduce this/build E2E test cases
for this. We take the conservative route and assume that the failure
report is correct (I found similar reports affecting other APM tools)
and add a try/catch arround the `sendBeacon` call to fall back to
regular `XMLHttpRequest` calls.