### PR TITLE
Remove unload listener

### DIFF
--- a/lib/events/onLastChance.js
+++ b/lib/events/onLastChance.js
@@ -3,11 +3,6 @@
 import { addEventListener } from '../util';
 import { doc, win } from '../browser';
 
-// Defined here until https://github.com/facebook/flow/pull/8371 is merged and released.
-class PageTransitionEvent extends Event {
-  persisted: boolean;
-}
-
 let isUnloading = false;
 
 export function onLastChance(fn: Function) {
@@ -22,16 +17,10 @@ export function onLastChance(fn: Function) {
   });
 
   // $FlowFixMe The type is correct, but flow doesn't think so. Ignore for now.
-  addEventListener(win, 'pagehide', function(event: PageTransitionEvent) {
-    if (event.persisted) {
-      isUnloading = true;
-      fn();
-    }
+  addEventListener(win, 'pagehide', function() {
+    isUnloading = true;
+    fn();
   });
-
-  // Unload is needed to fix this bug:
-  // https://bugs.chromium.org/p/chromium/issues/detail?id=987409
-  addEventListener(win, 'unload', function() {});
 
   // According to the spec visibilitychange should be a replacement for
   // beforeunload, but the reality is different (as of 2019-04-17). Chrome will

--- a/lib/webVitals.js
+++ b/lib/webVitals.js
@@ -11,9 +11,15 @@ interface Metric {
 }
 
 export function addWebVitals(beacon: PageLoadBeacon) {
-  getLCP(onMetric, true);
-  getFID(onMetric, true);
-  getCLS(onMetricWithoutRounding, true);
+  if (getLCP) {
+    getLCP(onMetric, true);
+  }
+  if (getFID) {
+    getFID(onMetric, true);
+  }
+  if (getCLS) {
+    getCLS(onMetricWithoutRounding, true);
+  }
 
   function onMetric(metric: Metric) {
     beacon['t_' + metric.name.toLocaleLowerCase()] = Math.round(metric.value);

--- a/lib/webVitals.js
+++ b/lib/webVitals.js
@@ -1,7 +1,7 @@
 // @flow
 
 // $FlowFixMe Flow doesn't find the file. Let's ignore this for now.
-import { getCLS, getLCP, getFID } from 'web-vitals/dist/web-vitals.es5.min.js';
+import { getCLS, getLCP, getFID } from 'web-vitals/dist/web-vitals.js';
 import type {PageLoadBeacon} from './types';
 
 interface Metric {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7472,9 +7472,9 @@
       }
     },
     "web-vitals": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-0.2.3.tgz",
-      "integrity": "sha512-6idlbUoL38El+QS320Qz6h4QSZLaWw3CHiJWBtQDmFGs72ro+fnukfavTxTdQSlsaoaBuNL/0bqlIhfdtlrx4A=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-1.1.1.tgz",
+      "integrity": "sha512-jYOaqu01Ny1NvMwJ3dBJDUOJ2PGWknZWH4AUnvFOscvbdHMERIKT2TlgiAey5rVyfOePG7so2JcXXZdSnBvioQ=="
     },
     "webdriver-js-extender": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "webdriver-manager": "^10.2.8"
   },
   "dependencies": {
-    "web-vitals": "^0.2.3"
+    "web-vitals": "1.1.1"
   }
 }

--- a/protractor.saucelabs.config.js
+++ b/protractor.saucelabs.config.js
@@ -5,6 +5,7 @@ exports.config = {
   sauceUser: process.env.SAUCE_USERNAME,
   sauceKey: process.env.SAUCE_ACCESS_KEY,
   sauceBuild: process.env.TRAVIS_JOB_NUMBER,
+  // See https://wiki.saucelabs.com/display/DOCS/Platform+Configurator#/
   multiCapabilities: [
     newSaucelabsCapability('internet explorer', '11.103', 'Windows 10'),
     newSaucelabsCapability('MicrosoftEdge', '14.14393', 'Windows 10'),
@@ -12,7 +13,7 @@ exports.config = {
     newSaucelabsCapability('safari', '10.1', 'macOS 10.12'),
     newSaucelabsCapability('safari', '11.0', 'macOS 10.12'),
     newSaucelabsCapability('safari', '11.1', 'macOS 10.13'),
-    newSaucelabsCapability('firefox', '48.0', 'Windows 7'),
+    newSaucelabsCapability('firefox', '78.0', 'Windows 7'),
     newSaucelabsCapability('firefox', '59.0', 'Windows 10'),
     newSaucelabsCapability('chrome', '48.0', 'Windows 10'),
     newSaucelabsCapability('chrome', '54.0', 'OS X 10.11'),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,6 +6,8 @@ const babel = require('rollup-plugin-babel');
 const path = require('path');
 const fs = require('fs');
 
+const secureWebVitalsLoader = require('./secureWebVitalsLoader');
+
 const isDebugBuild = process.env.NODE_ENV !== 'production';
 
 export default {
@@ -20,6 +22,7 @@ export default {
       exclude: 'node_modules/**',
       plugins: getPlugins()
     }),
+    secureWebVitalsLoader(),
     replace({
       DEBUG: JSON.stringify(isDebugBuild)
     }),

--- a/secureWebVitalsLoader.js
+++ b/secureWebVitalsLoader.js
@@ -1,0 +1,18 @@
+/* eslint-env node */
+
+const fs = require('fs');
+
+module.exports = () => ({
+  name: 'secureWebVitalsLoader',
+  load(id) {
+    if (id.endsWith('web-vitals/dist/web-vitals.js')) {
+      console.log('Adding try/catch to the web-vitals module');
+      const content = fs.readFileSync(id, {encoding: 'utf8'});
+      const parts = content.split('export{');
+      if (parts.length !== 2) {
+        throw new Error('web-vitals module must have changed. Cannot auto-wrap it with try/catch.');
+      }
+      return `try {${parts[0]}} catch (e) {}export{${parts[1]}`;
+    }
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5747,10 +5747,10 @@ walker@^1.0.7, walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
-web-vitals@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-0.2.3.tgz#950adea6da9e3cfd3ee2ffe868c7126a6d87b2d1"
-  integrity sha512-6idlbUoL38El+QS320Qz6h4QSZLaWw3CHiJWBtQDmFGs72ro+fnukfavTxTdQSlsaoaBuNL/0bqlIhfdtlrx4A==
+web-vitals@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-1.1.1.tgz#2df535e3355fb7fbe34787b44b736e270e539377"
+  integrity sha512-jYOaqu01Ny1NvMwJ3dBJDUOJ2PGWknZWH4AUnvFOscvbdHMERIKT2TlgiAey5rVyfOePG7so2JcXXZdSnBvioQ==
 
 webdriver-js-extender@2.1.0:
   version "2.1.0"


### PR DESCRIPTION
# Why

`unload` makes pages inelligible for bfcache optimizations. This
might be observed by our customers as part of newer Lighthouse
audits.

# What

Remove the `unload` event registration and rely on the other
existing events. This is in line with recent learnings of the
web-vitals lib.