### PR TITLE
feat: add debug command

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -104,6 +104,11 @@ export function processCommand(command: any[]): any {
     }
     vars.urlsToCheckForGraphQlInsights = command[1];
     break;
+  case 'debug':
+    // Not using an if (DEBUG) {…} wrapper nor the integrated logging
+    // facilities to keep the end-user impact as low as possible.
+    console.log({vars});
+    break;
   default:
     if (DEBUG) {
       warn('Unsupported command: ' + command[0]);


### PR DESCRIPTION
# Why

For customer support cases, it can sometimes be really helpful to
inspect weasel's configuration data. Especially, to understand
missing/too much monitoring data caused by configurations such as
`ignoreUrls`.

# What

Add a low-impact `eum('debug')` command that support staff could
use on customers' websites. This can be handy for experienced
support staff to get an understanding for custom configurations.