### PR TITLE
stop flow servers after running flow in npm run test:flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:e2e:local": "export IS_TEST=true && protractor protractor.local.config.js",
     "test:e2e:saucelabs": "export IS_TEST=true && protractor protractor.saucelabs.config.js",
     "test:lint": "eslint lib/**/*.js test/**/*.js",
-    "test:flow": "flow; test $? -eq 0 -o $? -eq 2",
+    "test:flow": "flow; FLOW_RESULT=$?; flow stop; test $FLOW_RESULT -eq 0 -o $? -eq 2",
     "webdriver:start": "webdriver-manager update && webdriver-manager start",
     "devServer": "BEACON_SERVER_PORTS='3009,3010,3011' node test/server/server",
     "fileStats": "echo \"\nFile Stats:\" && ls target/*.js | xargs -I '%' bash -c 'echo \"%: $(./node_modules/.bin/gzip-size % | ./node_modules/.bin/pretty-bytes) (gzip)\"'"


### PR DESCRIPTION
The flow command in the test:flow command (implicitly triggerd by
npm test) starts a bunch of flow servers (depending on the number of
available cores) and leaves them running afterwards. This might make
sense if you work on this package directly, to speed up consecutive
builds by a few milliseconds. But weasel is routinely included in other
projects as a sub-dependency, which also means triggering weasel builds
as part of the build of that larger system. Leaving ~20 processes behind
after such a build is not great.

Starting the flow servers every time they are needed (and stopping them
afterwards) does not take long and it seems to be an acceptable
tradeoff.