### PR TITLE
Wrong page information associated to error beacons

### DIFF
--- a/test/e2e/02_error/error.spec.js
+++ b/test/e2e/02_error/error.spec.js
@@ -124,4 +124,22 @@ describe('02_error', () => {
       });
     });
   });
+
+  describe('manual reporting with page change', () => {
+    beforeEach(() => {
+      browser.get(getE2ETestBaseUrl('02_error/manualWithPageChange'));
+    });
+
+    fit('must support manual error reporting with page changes', () => {
+      return retry(() => {
+        return getBeacons().then(beacons => {
+          expectOneMatching(beacons, beacon => {
+            cexpect(beacon.ty).to.equal('err');
+            cexpect(beacon.e).to.equal('This should have occurred on page 1');
+            cexpect(beacon.p).to.equal('page1');
+          });
+        });
+      });
+    });
+  });
 });

--- a/test/e2e/02_error/manualWithPageChange.html
+++ b/test/e2e/02_error/manualWithPageChange.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>error test</title>
+
+  <script src="/e2e/initializer.js"></script>
+  <script crossorigin="anonymous" defer src="/target/eum.min.js"></script>
+  <script>
+    eum('page', 'page1');
+    eum('reportError', new Error('This should have occurred on page 1'));
+    eum('page', 'page2')
+  </script>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.js"></script>
+</head>
+<body>
+  manual error reporting with page change
+</body>
+</html>


### PR DESCRIPTION
# Why

Wrong page information gets associated to error beacons when navigating
away from a broken page right after an error occurred.

# What

Add a reproducer (work to be continued).