### PR TITLE
Performance mark duration to reflect startTime

### DIFF
--- a/lib/hooks/userTiming.js
+++ b/lib/hooks/userTiming.js
@@ -35,17 +35,25 @@ function onUserTiming(performanceEntry: PerformanceEntry) {
   }
 
   let duration;
+  let timestamp;
   if (performanceEntry.entryType !== 'mark') {
     duration = Math.round(performanceEntry.duration);
+    timestamp = Math.max(
+      pageLoadStartTimestamp,
+      Math.round(performance['timeOrigin'] + performanceEntry.startTime)
+    );
+  } else {
+    duration = Math.round(performanceEntry.startTime);
+    timestamp = Math.max(
+      pageLoadStartTimestamp,
+      Math.round(performance['timeOrigin'])
+    );
   }
 
   // $FlowFixMe: Flow cannot detect that this is a proper usage of the function. We have to write it this way because of the Closure compiler advanced mode.
   reportCustomEvent(performanceEntry.name, {
     // Do not allow the timestamp to be before our Notion of page load start.
-    'timestamp': Math.max(
-      pageLoadStartTimestamp,
-      Math.round(performance['timeOrigin'] + performanceEntry.startTime)
-    ),
+    'timestamp': timestamp,
     'duration': duration,
     'meta': {
       'userTimingType': performanceEntry.entryType

--- a/lib/hooks/userTiming.js
+++ b/lib/hooks/userTiming.js
@@ -38,22 +38,19 @@ function onUserTiming(performanceEntry: PerformanceEntry) {
   let timestamp;
   if (performanceEntry.entryType !== 'mark') {
     duration = Math.round(performanceEntry.duration);
-    timestamp = Math.max(
-      pageLoadStartTimestamp,
-      Math.round(performance['timeOrigin'] + performanceEntry.startTime)
-    );
+    timestamp = Math.round(performance['timeOrigin'] + performanceEntry.startTime);
   } else {
     duration = Math.round(performanceEntry.startTime);
-    timestamp = Math.max(
-      pageLoadStartTimestamp,
-      Math.round(performance['timeOrigin'])
-    );
+    timestamp = Math.round(performance['timeOrigin']);
   }
 
   // $FlowFixMe: Flow cannot detect that this is a proper usage of the function. We have to write it this way because of the Closure compiler advanced mode.
   reportCustomEvent(performanceEntry.name, {
     // Do not allow the timestamp to be before our Notion of page load start.
-    'timestamp': timestamp,
+    'timestamp': Math.max(
+      pageLoadStartTimestamp,
+      timestamp
+    ),
     'duration': duration,
     'meta': {
       'userTimingType': performanceEntry.entryType

--- a/test/e2e/11_userTiming/userTiming.spec.js
+++ b/test/e2e/11_userTiming/userTiming.spec.js
@@ -38,8 +38,7 @@ describe('11_userTiming', () => {
         const startWorkBeacon = expectOneMatching(beacons, beacon => {
           cexpect(beacon.ty).to.equal('cus');
           cexpect(beacon.n).to.equal('startWork');
-          cexpect(Number(beacon.ts)).to.be.at.least(Number(pageLoadBeacon.r));
-          cexpect(beacon.d).to.equal(undefined);
+          cexpect(beacon.d).not.to.equal('0');
           cexpect(beacon.m_userTimingType).to.equal('mark');
         });
 
@@ -47,14 +46,14 @@ describe('11_userTiming', () => {
           cexpect(beacon.ty).to.equal('cus');
           cexpect(beacon.n).to.equal('endWork');
           cexpect(Number(beacon.ts)).to.be.at.least(Number(startWorkBeacon.ts));
-          cexpect(beacon.d).to.equal(undefined);
+          cexpect(beacon.d).not.to.equal('0');
           cexpect(beacon.m_userTimingType).to.equal('mark');
         });
 
         expectOneMatching(beacons, beacon => {
           cexpect(beacon.ty).to.equal('cus');
           cexpect(beacon.n).to.equal('work');
-          cexpect(beacon.ts).to.equal(startWorkBeacon.ts);
+          cexpect(Number(beacon.ts)).to.equal(Number(startWorkBeacon.ts) + Number(startWorkBeacon.d));
           cexpect(beacon.d).not.to.equal('0');
           cexpect(beacon.m_userTimingType).to.equal('measure');
         });


### PR DESCRIPTION
# Why

User timing marks automatically picked up picked up by Weasel currently do not carry any duration making them less useful.

# What

Turn the user timing marks start time into the custom event's duration
Add an end2end test to validate that this works

