### PR TITLE
Strip secrets from query parameters of captured URLs

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -104,6 +104,12 @@ export function processCommand(command: any[]): any {
     }
     vars.urlsToCheckForGraphQlInsights = command[1];
     break;
+  case 'secrets':
+    if (DEBUG) {
+      validateRegExpArray('secrets', command[1]);
+    }
+    vars.secrets = command[1];
+    break;
   case 'debug':
     // Not using an if (DEBUG) {…} wrapper nor the integrated logging
     // facilities to keep the end-user impact as low as possible.

--- a/lib/commonBeaconProperties.js
+++ b/lib/commonBeaconProperties.js
@@ -1,4 +1,5 @@
 import type {Beacon, Meta} from './types';
+import {stripSecrets} from './stripSecrets';
 import {win, doc, nav} from './browser';
 import {hasOwnProperty} from './util';
 import {getActivePhase} from './fsm';
@@ -15,7 +16,7 @@ export function addCommonBeaconProperties(beacon: Beacon) {
   beacon['sv'] = vars.trackingSnippetVersion;
   beacon['r'] = vars.referenceTimestamp;
   beacon['p'] = vars.page;
-  beacon['l'] = win.location.href;
+  beacon['l'] = stripSecrets(win.location.href);
   beacon['pl'] = vars.pageLoadTraceId;
   beacon['ui'] = vars.userId;
   beacon['un'] = vars.userName;

--- a/lib/hooks/Fetch.js
+++ b/lib/hooks/Fetch.js
@@ -8,6 +8,7 @@ import {observeResourcePerformance} from '../performanceObserver';
 import {now, generateUniqueId, matchesAny} from '../util';
 import {isAllowedOrigin} from '../allowedOrigins';
 import {sendBeacon} from '../transmission/index';
+import {stripSecrets} from '../stripSecrets';
 import {originalFetch, win} from '../browser';
 import {normalizeUrl} from './normalizeUrl';
 import {isUrlIgnored} from '../ignoreRules';
@@ -76,7 +77,7 @@ export function instrumentFetch() {
     beacon['t'] = spanAndTraceId;
     beacon['s'] = spanAndTraceId;
     beacon['m'] = request.method;
-    beacon['u'] = normalizeUrl(url);
+    beacon['u'] = stripSecrets(normalizeUrl(url));
     beacon['a'] = 1;
     beacon['bc'] = setBackendCorrelationHeaders ? 1 : 0;
 

--- a/lib/hooks/XMLHttpRequest.js
+++ b/lib/hooks/XMLHttpRequest.js
@@ -7,6 +7,7 @@ import {addCommonBeaconProperties} from '../commonBeaconProperties';
 import {observeResourcePerformance} from '../performanceObserver';
 import {isAllowedOrigin} from '../allowedOrigins';
 import {sendBeacon} from '../transmission/index';
+import {stripSecrets} from '../stripSecrets';
 import {now, generateUniqueId} from '../util';
 import {normalizeUrl} from './normalizeUrl';
 import {isUrlIgnored} from '../ignoreRules';
@@ -110,7 +111,7 @@ export function instrumentXMLHttpRequest() {
       // xhr beacon specific data
       // 's': '',
       'm': method,
-      'u': normalizeUrl(url),
+      'u': stripSecrets(normalizeUrl(url)),
       'a': async === undefined || async ? 1 : 0,
       'st': 0,
       'e': undefined,

--- a/lib/resources/resources.js
+++ b/lib/resources/resources.js
@@ -3,6 +3,7 @@
 import {performance, isResourceTimingAvailable} from '../performance';
 import type {BeaconWithResourceTiming} from '../types';
 import {serializeEntry} from './timingSerializer';
+import {stripSecrets} from '../stripSecrets';
 import {isUrlIgnored} from '../ignoreRules';
 import {urlMaxLength} from './consts';
 import {createTrie} from '../trie';
@@ -62,7 +63,7 @@ function getEntriesTransferFormat(performanceEntries: Array<Object>, minStartTim
     // The XHR instrumentation is available once the initialization was executed
     // (which is completely synchronous).
     if (initiatorType !== 'xmlhttprequest' || entry['startTime'] < vars.highResTimestampReference) {
-      trie.addItem(url, serializeEntry(entry));
+      trie.addItem(stripSecrets(url), serializeEntry(entry));
     }
   }
 

--- a/lib/states/pageLoaded.js
+++ b/lib/states/pageLoaded.js
@@ -8,6 +8,7 @@ import type {State, PageLoadBeacon} from '../types';
 import {onLastChance} from '../events/onLastChance';
 import {sendBeacon} from '../transmission/index';
 import {setTimeout} from '../timers';
+import {stripSecrets} from '../stripSecrets';
 import {win, doc} from '../browser';
 import {info} from '../debug';
 import vars from '../vars';
@@ -24,7 +25,7 @@ const state: State = {
 
     beacon['t'] = vars.pageLoadTraceId;
     beacon['bt'] = vars.pageLoadBackendTraceId;
-    beacon['u'] = win.location.href;
+    beacon['u'] = stripSecrets(win.location.href);
     beacon['ph'] = pageLoadPhase;
 
     addTimingToPageLoadBeacon(beacon);

--- a/lib/stripSecrets.js
+++ b/lib/stripSecrets.js
@@ -1,0 +1,51 @@
+// @flow
+
+import { debug } from './debug';
+import { matchesAny } from './util';
+import vars from './vars';
+
+let urlAnalysisElement = null;
+
+try {
+  urlAnalysisElement = document.createElement('a');
+} catch (e) {
+  if (DEBUG) {
+    debug('Failed to create URL analysis element. Will not be able to normalize URLs.', e);
+  }
+}
+
+export function stripSecrets(url: string) {
+  if (!url || url === '') {
+    return url;
+  }
+
+  try {
+    if (urlAnalysisElement) {
+      urlAnalysisElement.href = url;
+      url = urlAnalysisElement.href;
+    }
+    const queryIndex = url.indexOf('?');
+
+    if (queryIndex >= 0) {
+      const queryString = url
+        .substring(queryIndex)
+        .split('&')
+        .map(function(param) {
+          const key = param.split('=')[0];
+          if (key && matchesAny(vars.secrets, key)) {
+            return key + '=<redacted>';
+          }
+          return param;
+        })
+        .join('&');
+
+      url = url.substring(0, queryIndex) + queryString;
+    }
+  } catch (e) {
+    if (DEBUG) {
+      debug('Failed to strip secret from ' + url);
+    }
+  }
+
+  return url;
+}

--- a/lib/vars.js
+++ b/lib/vars.js
@@ -256,7 +256,17 @@ const defaultVars: {
   // this, you can decide which URLs Weasel we analyze for GraphQL specifics.
   //
   // eum('urlsToCheckForGraphQlInsights', [/\/graphql/i]);
-  urlsToCheckForGraphQlInsights: RegExp[]
+  urlsToCheckForGraphQlInsights: RegExp[],
+
+  // A set of regular expression that will be matched against query parameters
+  // in any URL that collected. When matched, value of the query parameter will be
+  // set to <redacted>. By configuring this, data treated as secrets will not reach
+  // the backend for processing, thus, will not be available for analysis in the UI
+  // or retrieval via API. By default, 'key', 'password' and 'secret' query
+  // parameters are treated as secret data.
+  //
+  // eum('secrets',  [/mysecret/i]);
+  secrets: RegExp[]
 } = {
   nameOfLongGlobal: 'EumObject',
   trackingSnippetVersion: null,
@@ -303,7 +313,8 @@ const defaultVars: {
   // name marks used to create measures. This is surely not a comprehensive
   // solution to identify these cases, but should for now be sufficient.
   ignoreUserTimings: [/^\u269B/, /^\u26D4/, /^Zone(:|$)/, /^start /i, /^end /i],
-  urlsToCheckForGraphQlInsights: [/\/graphql/i]
+  urlsToCheckForGraphQlInsights: [/\/graphql/i],
+  secrets: [/key/i, /password/i, /secret/i]
 };
 
 export default defaultVars;

--- a/test/e2e/00_pageLoad/pageLoadStripSecrets.html
+++ b/test/e2e/00_pageLoad/pageLoadStripSecrets.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>pageLoad test</title>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.js"></script>
+</head>
+<body>
+  Strip 'secret' and 'account' from query string
+
+  <script src="/e2e/initializer.js"></script>
+  <script crossorigin="anonymous" defer src="/target/eum.min.js"></script>
+
+  <script>
+    eum('secrets', [/secret/i, /account/i]);
+  </script>
+</body>
+</html>

--- a/test/e2e/00_pageLoad/resourceStripSecrets.html
+++ b/test/e2e/00_pageLoad/resourceStripSecrets.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>pageLoad test</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Tangerine">
+</head>
+<body>
+  resource timings strip secrets
+
+  <script src="/e2e/initializer.js"></script>
+  <script crossorigin="anonymous" defer src="/target/eum.min.js"></script>
+
+  <script>
+    eum('secrets', [/family/i, /account/i]);
+  </script>
+
+</body>
+</html>

--- a/test/e2e/01_xhr/xhr.spec.js
+++ b/test/e2e/01_xhr/xhr.spec.js
@@ -268,6 +268,28 @@ describe('xhr', () => {
     });
   });
 
+  describe('xhrStripSecrets', () => {
+    beforeEach(() => {
+      browser.get(getE2ETestBaseUrl('01_xhr/xhrStripSecrets'));
+    });
+
+    it('must strip secrets from url in send beacons', () => {
+      return whenXhrInstrumentationIsSupported(() =>
+        retry(() => {
+          return Promise.all([getBeacons()])
+            .then(([beacons]) => {
+              cexpect(beacons).to.have.lengthOf(2);
+
+              expectOneMatching(beacons, beacon => {
+                cexpect(beacon.ty).to.equal('xhr');
+                cexpect(beacon.u).to.match(/^http:\/\/127\.0\.0\.1:8000\/ajax\?mysecret=<redacted>&myaccountno=<redacted>&phone=999$/);
+              });
+
+            });
+        })
+      );
+    });
+  });
 
   function whenXhrInstrumentationIsSupported(fn) {
     return whenConfigMatches(

--- a/test/e2e/01_xhr/xhrStripSecrets.html
+++ b/test/e2e/01_xhr/xhrStripSecrets.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>xhr test</title>
+
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.js"></script>
+</head>
+<body>
+  ajax strip secret
+
+  <div id="result"></div>
+
+  <script src="/e2e/initializer.js"></script>
+  <!-- Ensure synchronous load for more reliable tests -->
+  <script crossorigin="anonymous" src="/target/eum.min.js"></script>
+  <script>
+    eum('secrets', [/secret/i, /account/i]);
+    $.ajax({
+      url: '/ajax' + '?mysecret=password&myaccountno=myaccount&phone=999',
+      success: function(result) {
+        $('#result').text(result);
+      }
+    });
+  </script>
+</body>
+</html>

--- a/test/e2e/05_fetch/fetch.spec.js
+++ b/test/e2e/05_fetch/fetch.spec.js
@@ -453,6 +453,29 @@ describe('05_fetch', () => {
     });
   });
 
+  describe('05_fetchStripScerets', () => {
+    beforeEach(() => {
+      browser.get(getE2ETestBaseUrl('05_fetch/fetchStripSecrets'));
+    });
+
+    it('must strip secrets from url in send beacons', () => {
+      return whenFetchIsSupported(() =>
+        retry(() => {
+          return Promise.all([getBeacons()]).then(([beacons]) => {
+            cexpect(beacons).to.have.lengthOf(2);
+
+            expectOneMatching(beacons, beacon => {
+              cexpect(beacon.ty).to.equal('xhr');
+              cexpect(beacon.u).to.match(
+                /^http:\/\/127\.0\.0\.1:8000\/ajax\?mysecret=<redacted>&myaccountno=<redacted>&phone=999$/
+              );
+            });
+          });
+        })
+      );
+    });
+  });
+
   function whenFetchIsSupported(fn) {
     return whenConfigMatches(
       config => {

--- a/test/e2e/05_fetch/fetchStripSecrets.html
+++ b/test/e2e/05_fetch/fetchStripSecrets.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>fetch test</title>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.js"></script>
+</head>
+<body>
+  fetch before page load
+
+  <div id="result"></div>
+
+  <script src="/e2e/initializer.js"></script>
+  <!-- Ensure synchronous load for more reliable tests -->
+  <script crossorigin="anonymous" src="/target/eum.min.js"></script>
+  <script>
+    eum('secrets', [/secret/i, /account/i]);
+    if (self.fetch) {
+      fetch('/ajax' + '?mysecret=password&myaccountno=myaccount&phone=999')
+      .then(function(response) {
+        return response.text();
+      })
+      .then(function(responseBody) {
+        $('#result').text(responseBody);
+      })
+      .catch(function(e) {
+        $('#result').text('error: ' + JSON.stringify(e));
+      });
+    } else {
+        $('#result').text('The Fetch API is not supported by this browser.');
+    }
+  </script>
+</body>
+</html>

--- a/test/unit/stripSecrets.test.js
+++ b/test/unit/stripSecrets.test.js
@@ -1,0 +1,48 @@
+jest.mock('../../lib/vars');
+
+describe('stripSecrets', () => {
+  let varsMock;
+  let stripSecrets;
+  let url;
+  let urlRedacted;
+
+  beforeEach(() => {
+    self.DEBUG = false;
+    const stripSecretsMock = require('../../lib/stripSecrets');
+    stripSecrets = stripSecretsMock.stripSecrets;
+    varsMock = require('../../lib/vars').default;
+    varsMock.secrets = [/account/i, /pass/i];
+    global.DEBUG = false;
+  });
+
+  afterEach(() => {
+    delete global.DEBUG;
+  });
+
+  it('strip secret from url with multiple query parameters', () => {
+    url = 'http://example.com/search?accountno=user01&pass=password&phoneno=999';
+    urlRedacted = 'http://example.com/search?accountno=<redacted>&pass=<redacted>&phoneno=999';
+    expect(stripSecrets(url)).toEqual(urlRedacted);
+  });
+
+  it('strip secret from url with single query parameter', () => {
+    url = 'http://example.com/search?accountno=user01';
+    urlRedacted = 'http://example.com/search?accountno=<redacted>';
+    expect(stripSecrets(url)).toEqual(urlRedacted);
+    url = 'http://example.com/search?DATA=[{"T":"Info", "FID":"CI", "Name":"HasRR","Text":"1"}]';
+    urlRedacted =
+      'http://example.com/search?DATA=[{%22T%22:%22Info%22,%20%22FID%22:%22CI%22,%20%22Name%22:%22HasRR%22,%22Text%22:%221%22}]';
+    expect(stripSecrets(url)).toEqual(urlRedacted);
+  });
+
+  it('strip secret from url with no query parameter', () => {
+    url = 'http://example.com/search';
+    expect(stripSecrets(url)).toEqual(url);
+  });
+
+  it('strip secret from invalid url', () => {
+    expect(stripSecrets(null)).toEqual(null);
+    url = 'invalid://example.com/search?phoneno=999';
+    expect(stripSecrets(url)).toEqual(url);
+  });
+});


### PR DESCRIPTION
# Why

It is a common need to pass some information to servers via query parameters that can be considered secrets. In those cases, the HTTP requests themselves should be monitored, but the secret should be stripped.

# What

Add a `eum('secrets', [/regular expressions/]);` command to support configuration of secrets. Default configuration is equivalent to `eum('secrets', [/key/i, /password/i, /secret/i]); `  When key of a query parameter matched, its value will replaced with `<redacted>`.
