### PR TITLE
Filter out duplicate resource with initiatorType as fetch

### DIFF
--- a/lib/resources/resources.js
+++ b/lib/resources/resources.js
@@ -62,7 +62,7 @@ function getEntriesTransferFormat(performanceEntries: Array<Object>, minStartTim
     // We provide more detailed XHR insights via our XHR instrumentation.
     // The XHR instrumentation is available once the initialization was executed
     // (which is completely synchronous).
-    if (initiatorType !== 'xmlhttprequest' || entry['startTime'] < vars.highResTimestampReference) {
+    if ((initiatorType !== 'xmlhttprequest' && initiatorType !== 'fetch') || entry['startTime'] < vars.highResTimestampReference) {
       trie.addItem(stripSecrets(url), serializeEntry(entry));
     }
   }


### PR DESCRIPTION
**WHY:**
We observered that weasel might capture duplicate beacons, one is XHR/fetch request, the other is page resource with initiatorType=other. 

![capture_duplicate_beacons_with_both_XHR_and_page_resource](https://user-images.githubusercontent.com/31396405/177908771-d613c64b-a880-4e89-909f-be4cc237e4f6.png)

**WHAT:**
Since Fetch request has more detailed insight, we will filter out the page resource with initiatorType=fetch.

![PerformanceResourceTiming_with_initiatorType_fetch](https://user-images.githubusercontent.com/31396405/177908964-9e0f4b34-b782-4a54-a7e1-8af40f50e680.png)
