### PR TITLE
Keep original method signature in instrumentation of fetch API

### DIFF
--- a/lib/hooks/Fetch.js
+++ b/lib/hooks/Fetch.js
@@ -31,8 +31,6 @@ export function instrumentFetch() {
   }
 
   win.fetch = function(input, init) {
-    const request = new Request(input, init);
-
     if (isExcessiveUsage()) {
       if (DEBUG) {
         info('Reached the maximum number of fetch calls to monitor.');
@@ -40,6 +38,7 @@ export function instrumentFetch() {
       return originalFetch(input, init);
     }
 
+    const request = new Request(input, init);
     const url = request.url;
 
     if (isUrlIgnored(url)) {
@@ -48,7 +47,7 @@ export function instrumentFetch() {
           'Not generating XHR beacon for fetch call because it is to be ignored according to user configuration. URL: ' + url
         );
       }
-      return originalFetch(input, init);
+      return originalFetch(request, init);
     }
 
     // $FlowFixMe: Some properties deliberately left our for js file size reasons.

--- a/lib/hooks/Fetch.js
+++ b/lib/hooks/Fetch.js
@@ -82,7 +82,14 @@ export function instrumentFetch() {
     beacon['bc'] = setBackendCorrelationHeaders ? 1 : 0;
 
     if (setBackendCorrelationHeaders) {
-      addCorrelationHttpHeaders(request.headers.append, request.headers, spanAndTraceId);
+      if (init && init.headers) {
+        if (!(init.headers instanceof Headers)) {
+          init.headers = new Headers(init.headers);
+        }
+        addCorrelationHttpHeaders(init.headers.append, init.headers, spanAndTraceId);
+      } else {
+        addCorrelationHttpHeaders(request.headers.append, request.headers, spanAndTraceId);
+      }
     }
 
     try{
@@ -95,7 +102,6 @@ export function instrumentFetch() {
       }
     }
 
-
     const performanceObserver = observeResourcePerformance({
       entryTypes: ['resource'],
       resourceMatcher,
@@ -104,7 +110,7 @@ export function instrumentFetch() {
     });
     performanceObserver.onBeforeResourceRetrieval();
 
-    return originalFetch(input, init)
+    return originalFetch(request, init)
       .then(function(response) {
         beacon['st'] = response.status;
         try {

--- a/lib/hooks/Fetch.js
+++ b/lib/hooks/Fetch.js
@@ -37,7 +37,7 @@ export function instrumentFetch() {
       if (DEBUG) {
         info('Reached the maximum number of fetch calls to monitor.');
       }
-      return originalFetch(request);
+      return originalFetch(input, init);
     }
 
     const url = request.url;
@@ -48,7 +48,7 @@ export function instrumentFetch() {
           'Not generating XHR beacon for fetch call because it is to be ignored according to user configuration. URL: ' + url
         );
       }
-      return originalFetch(request);
+      return originalFetch(input, init);
     }
 
     // $FlowFixMe: Some properties deliberately left our for js file size reasons.
@@ -104,7 +104,7 @@ export function instrumentFetch() {
     });
     performanceObserver.onBeforeResourceRetrieval();
 
-    return originalFetch(request)
+    return originalFetch(input, init)
       .then(function(response) {
         beacon['st'] = response.status;
         try {

--- a/test/e2e/05_fetch/fetch.spec.js
+++ b/test/e2e/05_fetch/fetch.spec.js
@@ -219,6 +219,54 @@ describe('05_fetch', () => {
     });
   });
 
+  describe('05_fetchRequestObjectAndInitObjectWithoutHeaders', () => {
+    beforeEach(() => {
+      browser.get(getE2ETestBaseUrl('05_fetch/requestObjectAndInitObjectWithoutHeaders'));
+    });
+
+    it('must handle request and init object correctly', () => {
+      return whenFetchIsSupported(() =>
+        retry(() => {
+          return Promise.all([getBeacons(), getAjaxRequests(), getResultElementContent()])
+            .then(([beacons, ajaxRequests, result]) => {
+              cexpect(beacons).to.have.lengthOf(2);
+              cexpect(ajaxRequests).to.have.lengthOf(1);
+
+              const pageLoadBeacon = expectOneMatching(beacons, beacon => {
+                cexpect(beacon.s).to.equal(undefined);
+              });
+
+              const ajaxBeacon = expectOneMatching(beacons, beacon => {
+                cexpect(beacon.t).to.match(/^[0-9A-F]{1,16}$/i);
+                cexpect(beacon.t).to.equal(beacon.s);
+                cexpect(beacon.r).not.to.be.NaN;
+                cexpect(beacon.ts).not.to.be.NaN;
+                cexpect(beacon.d).not.to.be.NaN;
+                cexpect(beacon.l).to.equal(getE2ETestBaseUrl('05_fetch/requestObjectAndInitObjectWithoutHeaders'));
+                cexpect(beacon.ty).to.equal('xhr');
+                cexpect(beacon.pl).to.equal(pageLoadBeacon.t);
+                cexpect(beacon.m).to.equal('POST');
+                cexpect(beacon.u).to.match(/^http:\/\/127\.0\.0\.1:8000\/ajax\?cacheBust=\d+$/);
+                cexpect(beacon.a).to.equal('1');
+                cexpect(beacon.st).to.equal('200');
+                cexpect(beacon.bc).to.equal('1');
+                cexpect(beacon.e).to.be.undefined;
+              });
+
+              const ajaxRequest = expectOneMatching(ajaxRequests, ajaxRequest => {
+                cexpect(ajaxRequest.method).to.equal('POST');
+                cexpect(ajaxRequest.url).to.match(/^\/ajax\?cacheBust=\d+$/);
+                cexpect(ajaxRequest.headers['x-instana-t']).to.equal(ajaxBeacon.t);
+                cexpect(ajaxRequest.headers['x-instana-s']).to.equal(ajaxBeacon.s);
+                cexpect(ajaxRequest.headers['x-instana-l']).to.equal('1,correlationType=web;correlationId=' + ajaxBeacon.t);
+              });
+
+              cexpect(result).to.equal(ajaxRequest.response);
+            });
+        })
+      );
+    });
+  });
 
   describe('05_fetchBeforePageLoad', () => {
     beforeEach(() => {

--- a/test/e2e/05_fetch/requestObjectAndInitObjectWithoutHeaders.html
+++ b/test/e2e/05_fetch/requestObjectAndInitObjectWithoutHeaders.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>fetch test</title>
+  <script src="/e2e/initializer.js"></script>
+  <script crossorigin="anonymous" defer src="/target/eum.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.js"></script>
+</head>
+<body>
+  fetch with request object
+
+  <div id="result"></div>
+
+  <script>
+    $(window).on('load', function() {
+      setTimeout(function() {
+        if (self.fetch && self.Request) {
+          var request = new Request('/ajax' + '?cacheBust=' + (new Date()).getTime());
+
+          fetch(request, {
+            method: 'POST'
+          })
+          .then(function(response) {
+            return response.text();
+          })
+          .then(function(responseBody) {
+            $('#result').text(responseBody);
+          })
+          .catch(function(e) {
+            $('#result').text('error: ' + JSON.stringify(e));
+          });
+        } else {
+            $('#result').text('The Fetch/Request object API is not supported by this browser.');
+        }
+      }, 100);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
**WHY:**
During instrumentation of Fetch API, weasel changes the method signature and causes request body to be opaque. It would be a problem when weasel co-exists with other libs which also instrument Fetch API.

**WHAT:**
Update the instrumentation to use the original method signature.
