### PR TITLE
validate backend trace id and drop invalid ones in custom event

### DIFF
--- a/lib/customEvents.js
+++ b/lib/customEvents.js
@@ -61,8 +61,9 @@ function enrich(beacon: CustomEventBeacon, opts: CustomEventOptions) {
     beacon['ts'] = opts['timestamp'];
   }
 
-  if (typeof opts['backendTraceId'] === 'string') {
-    beacon['bt'] = opts['backendTraceId'].substring(0, 64);
+  if (typeof opts['backendTraceId'] === 'string'
+    && (opts['backendTraceId'].length === 16 || opts['backendTraceId'].length === 32)) {
+    beacon['bt'] = opts['backendTraceId'];
   }
 
   if (opts['error']) {

--- a/test/e2e/09_customEvents/simpleEventReporting.html
+++ b/test/e2e/09_customEvents/simpleEventReporting.html
@@ -13,7 +13,7 @@
 
     eum('reportEvent', 'myTestEvent', {
       duration: 42,
-      backendTraceId: 'ab87128kja1kl',
+      backendTraceId: 'ab87128a1ff99345',
       error: new Error('Testing 123'),
       componentStack: 'a component stack',
       meta: {

--- a/test/unit/__snapshots__/resources.test.js.snap
+++ b/test/unit/__snapshots__/resources.test.js.snap
@@ -24,7 +24,7 @@ Object {
 exports[`resources/timingSerializer serializeEntry must identify full asset retrieval 1`] = `
 Object {
   "appcache": "",
-  "backendTraceId": "jkdlasj31kjjkl",
+  "backendTraceId": "3748eabc1876cdaa",
   "cachingType": "fullLoad",
   "decodedBodySize": "16786",
   "dns": "",

--- a/test/unit/resources.test.js
+++ b/test/unit/resources.test.js
@@ -86,7 +86,7 @@ describe('resources/timingSerializer', () => {
         serverTiming: [
           {
             name: 'intid',
-            description: 'jkdlasj31kjjkl'
+            description: '3748eabc1876cdaa'
           }
         ]
       };


### PR DESCRIPTION
**WHY:**
In some cases, user might input invalid backend trace id in custom event API by accident. An valid trace id should be 16 or 32 hex string.

**WHAT:**
Validate on backend trace id and drop invalid ones in custom event.

Note, during validation, checking on hex is not cost-efficient, so only check the length of string.