### PR TITLE
Update hook of Fetch API

### DIFF
--- a/lib/hooks/Fetch.js
+++ b/lib/hooks/Fetch.js
@@ -38,16 +38,28 @@ export function instrumentFetch() {
       return originalFetch(input, init);
     }
 
-    const request = new Request(input, init);
-    const url = request.url;
+    let body;
+    if (init && init.body) {
+      body = init.body;
+      init.body = undefined;
+    }
 
+    const request = new Request(input, init);
+    if (body) {
+      init.body = body;
+    }
+
+    const url = request.url;
     if (isUrlIgnored(url)) {
       if (DEBUG) {
         debug(
           'Not generating XHR beacon for fetch call because it is to be ignored according to user configuration. URL: ' + url
         );
       }
-      return originalFetch(request, init);
+      // could not use the original Request as it would encounter error that
+      // either "Request body is already used"
+      // or "Cannot construct a Request with a Request object that has already been used"
+      return originalFetch(input instanceof Request ? request : input, init);
     }
 
     // $FlowFixMe: Some properties deliberately left our for js file size reasons.
@@ -86,15 +98,21 @@ export function instrumentFetch() {
           init.headers = new Headers(init.headers);
         }
         addCorrelationHttpHeaders(init.headers.append, init.headers, spanAndTraceId);
-      } else {
+      } else if (input instanceof Request) {
         addCorrelationHttpHeaders(request.headers.append, request.headers, spanAndTraceId);
+      } else {
+        if (!init) {
+          init = {};
+        }
+        init.headers = new Headers();
+        addCorrelationHttpHeaders(init.headers.append, init.headers, spanAndTraceId);
       }
     }
 
     try{
       captureHttpHeaders(request.headers, beacon);
     } catch(e) {
-      if(DEBUG) {
+      if (DEBUG) {
         //it is possible without CORS, the Headers.forEach()
         //could throw errors with some browsers.
         warn('error during request.headers.forEach()');
@@ -109,13 +127,13 @@ export function instrumentFetch() {
     });
     performanceObserver.onBeforeResourceRetrieval();
 
-    return originalFetch(request, init)
+    return originalFetch(input instanceof Request ? request : input, init)
       .then(function(response) {
         beacon['st'] = response.status;
         try {
           captureHttpHeaders(response.headers, beacon);
         } catch(e) {
-          if(DEBUG) {
+          if (DEBUG) {
             //it is possible without CORS, the Headers.forEach()
             //could throw errors with some browsers.
             warn('error during response.headers.forEach()');
@@ -197,8 +215,8 @@ function captureHttpHeaders(headers, beacon) {
     return;
   }
 
-  headers.forEach(function(value, name){
-    if(matchesAny(vars.headersToCapture, name)){
+  headers.forEach(function(value, name) {
+    if (matchesAny(vars.headersToCapture, name)) {
       beacon['h_'+name.toLowerCase()] = value;
     }
   });

--- a/lib/hooks/XMLHttpRequest.js
+++ b/lib/hooks/XMLHttpRequest.js
@@ -180,7 +180,7 @@ export function instrumentXMLHttpRequest() {
         try{
           captureHttpHeaders(beacon, xhr.getAllResponseHeaders());
         } catch (e) {
-          if(DEBUG){
+          if (DEBUG) {
             //it is possible without CORS, the getAllResponseHeaders()
             //could throw errors with some browsers.
             warn('error during XMLHttpRequest.getAllResponseHeaders');
@@ -286,9 +286,9 @@ export function instrumentXMLHttpRequest() {
 
 export function captureHttpHeaders(beacon: XhrBeacon, headerString: string) {
   const lines = headerString.trim().split(/[\r\n]+/);
-  for( let i=0; i<lines.length; i++) {
+  for (let i=0; i<lines.length; i++) {
     const items = lines[i].split(': ', 2);
-    if(matchesAny(vars.headersToCapture, items[0])){
+    if (matchesAny(vars.headersToCapture, items[0])) {
       beacon['h_'+items[0].toLowerCase()] = items[1];
     }
   }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "gzip-size-cli": "^5.1.0",
     "husky": "^0.11.9",
     "jest": "^26.6.3",
+    "multiparty": "^4.2.3",
     "prettier": "^1.18.2",
     "pretty-bytes-cli": "^3.0.0",
     "protractor": "^7.0.0",

--- a/test/e2e/05_fetch/fetch.spec.js
+++ b/test/e2e/05_fetch/fetch.spec.js
@@ -562,6 +562,75 @@ describe('05_fetch', () => {
     });
   });
 
+  describe('05_fetchWithFormData', () => {
+    beforeEach(() => {
+      browser.get(getE2ETestBaseUrl('05_fetch/fetchWithFormData'));
+    });
+
+    it('must send form data in fetch requests', () => {
+      return whenFetchIsSupported(() =>
+        retry(() => {
+          return Promise.all([getBeacons(), getAjaxRequests(), getResultElementContent(), getCapabilities()])
+            .then(([beacons, ajaxRequests, result, capabilities]) => {
+              cexpect(beacons).to.have.lengthOf(2);
+              cexpect(ajaxRequests).to.have.lengthOf(1);
+
+              expectOneMatching(beacons, beacon => {
+                cexpect(beacon['l']).to.equal(getE2ETestBaseUrl('05_fetch/fetchWithFormData'));
+                cexpect(beacon['ty']).to.equal('xhr');
+                cexpect(beacon['m']).to.equal('POST');
+                cexpect(beacon['u']).to.match(/^http:\/\/127\.0\.0\.1:8000\/form+$/);
+              });
+
+              const ajaxRequest = expectOneMatching(ajaxRequests, ajaxRequest => {
+                cexpect(ajaxRequest.url).to.match(/^\/form+$/);
+                cexpect(ajaxRequest.headers['content-type']).to.contains('multipart/form-data;');
+                cexpect(ajaxRequest.fields['name']).to.contains('somename');
+                cexpect(ajaxRequest.fields['data']).to.contains('somedata');
+              });
+
+              cexpect(result).to.equal(ajaxRequest.response);
+
+            });
+        })
+      );
+    });
+  });
+
+  describe('05_fetchWithRequestObjectAndFormData', () => {
+    beforeEach(() => {
+      browser.get(getE2ETestBaseUrl('05_fetch/fetchWithRequestObjectAndFormData'));
+    });
+
+    it('must send form data in fetch requests', () => {
+      return whenFetchIsSupported(() =>
+        retry(() => {
+          return Promise.all([getBeacons(), getAjaxRequests(), getResultElementContent(), getCapabilities()])
+            .then(([beacons, ajaxRequests, result, capabilities]) => {
+              cexpect(beacons).to.have.lengthOf(2);
+              cexpect(ajaxRequests).to.have.lengthOf(1);
+
+              expectOneMatching(beacons, beacon => {
+                cexpect(beacon['l']).to.equal(getE2ETestBaseUrl('05_fetch/fetchWithRequestObjectAndFormData'));
+                cexpect(beacon['ty']).to.equal('xhr');
+                cexpect(beacon['m']).to.equal('POST');
+                cexpect(beacon['u']).to.match(/^http:\/\/127\.0\.0\.1:8000\/form+$/);
+              });
+
+              const ajaxRequest = expectOneMatching(ajaxRequests, ajaxRequest => {
+                cexpect(ajaxRequest.url).to.match(/^\/form+$/);
+                cexpect(ajaxRequest.headers['content-type']).to.contains('multipart/form-data;');
+                cexpect(ajaxRequest.fields['name']).to.contains('somename');
+                cexpect(ajaxRequest.fields['data']).to.contains('somedata');
+              });
+
+              cexpect(result).to.equal(ajaxRequest.response);
+            });
+        })
+      );
+    });
+  });
+
   function whenFetchIsSupported(fn) {
     return whenConfigMatches(
       config => {

--- a/test/e2e/05_fetch/fetchWithFormData.html
+++ b/test/e2e/05_fetch/fetchWithFormData.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>fetch test</title>
+  <script src="/e2e/initializer.js"></script>
+  <script crossorigin="anonymous" defer src="/target/eum.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.js"></script>
+</head>
+<body>
+  Fetch with form data
+  <div id="result"></div>
+  <script>
+    $(window).on('load', function() {
+      setTimeout(function() {
+        if (self.fetch) {
+          var formdata = new FormData();
+          formdata.append("data", "somedata");
+          formdata.append("name", "somename");
+          fetch('/form', {
+            method: 'POST',
+            body: formdata
+          })
+          .then(response => response.text())
+          .then(result => $('#result').text(result))
+          .catch(error => $('#result').text(error));
+
+        } else {
+            $('#result').text('The Fetch API is not supported by this browser.');
+        }
+      }, 100);
+    });
+  </script>
+</body>
+</html>

--- a/test/e2e/05_fetch/fetchWithRequestObjectAndFormData.html
+++ b/test/e2e/05_fetch/fetchWithRequestObjectAndFormData.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>fetch test</title>
+  <script src="/e2e/initializer.js"></script>
+  <script crossorigin="anonymous" defer src="/target/eum.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.js"></script>
+</head>
+<body>
+  Fetch with Request object and form data
+  <div id="result"></div>
+  <script>
+    $(window).on('load', function() {
+      setTimeout(function() {
+        if (self.fetch && self.Request) {
+          var formdata = new FormData();
+          formdata.append("data", "somedata");
+          formdata.append("name", "somename");
+          fetch(new Request('/form'), {
+            method: 'POST',
+            body: formdata
+          })
+          .then(response => response.text())
+          .then(result => $('#result').text(result))
+          .catch(error => $('#result').text(error));
+
+        } else {
+            $('#result').text('The Fetch API is not supported by this browser.');
+        }
+      }, 100);
+    });
+  </script>
+</body>
+</html>

--- a/test/server/server.js
+++ b/test/server/server.js
@@ -1,4 +1,5 @@
 const bodyParser = require('body-parser');
+const multiparty = require('multiparty');
 const serveIndex = require('serve-index');
 const express = require('express');
 const uuidV4 = require('uuid/v4');
@@ -106,6 +107,35 @@ app.all('/ajax', (req, res) => {
     params: req.params,
     headers: req.headers,
     response
+  });
+
+  // Delay responses to allow timeout tests.
+  setTimeout(() => {
+    res.send(response);
+  }, 100);
+});
+
+app.post('/form', (req, res) => {
+
+  const form = new multiparty.Form();
+  let response = uuidV4();
+  form.parse(req, function(err, fields) {
+    if (err) {
+      response = 'ERROR';
+    }
+
+    if (!fields) {
+      response = 'ERROR';
+    } else {
+      ajaxRequests.push({
+        method: req.method,
+        url: req.url,
+        params: req.params,
+        headers: req.headers,
+        response,
+        fields
+      });
+    }
   });
 
   // Delay responses to allow timeout tests.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4648,6 +4648,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"http-errors@npm:~1.8.1":
+  version: 1.8.1
+  resolution: "http-errors@npm:1.8.1"
+  dependencies:
+    depd: ~1.1.2
+    inherits: 2.0.4
+    setprototypeof: 1.2.0
+    statuses: ">= 1.5.0 < 2"
+    toidentifier: 1.0.1
+  checksum: d3c7e7e776fd51c0a812baff570bdf06fe49a5dc448b700ab6171b1250e4cf7db8b8f4c0b133e4bfe2451022a5790c1ca6c2cae4094dedd6ac8304a1267f91d2
+  languageName: node
+  linkType: hard
+
 "http-proxy-agent@npm:^5.0.0":
   version: 5.0.0
   resolution: "http-proxy-agent@npm:5.0.0"
@@ -6636,6 +6649,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"multiparty@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "multiparty@npm:4.2.3"
+  dependencies:
+    http-errors: ~1.8.1
+    safe-buffer: 5.2.1
+    uid-safe: 2.1.5
+  checksum: 16be1f14280a78a220864e9209196ce3d9bc5e3342a5e14465e8664c8a3f0e217b370d70f0dfba953ae7f17c720f87573b7b3b01a6e9eb04330c19f547ec157a
+  languageName: node
+  linkType: hard
+
 "mute-stream@npm:0.0.7":
   version: 0.0.7
   resolution: "mute-stream@npm:0.0.7"
@@ -7527,6 +7551,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"random-bytes@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "random-bytes@npm:1.0.0"
+  checksum: 09faa256394aa2ca9754aa57e92a27c452c3e97ffb266e98bebb517332e9df7168fea393159f88d884febce949ba8bec8ddb02f03342da6c6023ecc7b155e0ae
+  languageName: node
+  linkType: hard
+
 "range-parser@npm:~1.2.1":
   version: 1.2.1
   resolution: "range-parser@npm:1.2.1"
@@ -7992,6 +8023,7 @@ __metadata:
     gzip-size-cli: ^5.1.0
     husky: ^0.11.9
     jest: ^26.6.3
+    multiparty: ^4.2.3
     prettier: ^1.18.2
     pretty-bytes-cli: ^3.0.0
     protractor: ^7.0.0
@@ -9246,6 +9278,15 @@ __metadata:
   dependencies:
     is-typedarray: ^1.0.0
   checksum: 99c11aaa8f45189fcfba6b8a4825fd684a321caa9bd7a76a27cf0c7732c174d198b99f449c52c3818107430b5f41c0ccbbfb75cb2ee3ca4a9451710986d61a60
+  languageName: node
+  linkType: hard
+
+"uid-safe@npm:2.1.5":
+  version: 2.1.5
+  resolution: "uid-safe@npm:2.1.5"
+  dependencies:
+    random-bytes: ~1.0.0
+  checksum: 07536043da9a026f4a2bc397543d0ace7587449afa1d9d2c4fd3ce76af8a5263a678788bcc429dff499ef29d45843cd5ee9d05434450fcfc19cc661229f703d1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**WHY:**
The original hook of Fetch API breaks signature of method. It causes conflict with third-party libs. 


**WHAT:**
Update hook to match the signature of Fetch API. 