### PR TITLE
Deep copy options of Fetch instead of modifying original one

### DIFF
--- a/lib/hooks/Fetch.js
+++ b/lib/hooks/Fetch.js
@@ -16,6 +16,8 @@ import type {XhrBeacon} from '../types';
 import {debug, info, warn} from '../debug';
 import {isSameOrigin} from '../sop';
 import vars from '../vars';
+// $FlowFixMe Flow doesn't find the file. Let's ignore this for now.
+import objectAssign from 'object-assign';
 
 const isExcessiveUsage = createExcessiveUsageIdentifier({
   maxCallsPerTenMinutes: 256,
@@ -38,15 +40,17 @@ export function instrumentFetch() {
       return originalFetch(input, init);
     }
 
+    let copyInit = init ? objectAssign({}, init) : init;
+
     let body;
-    if (init && init.body) {
-      body = init.body;
-      init.body = undefined;
+    if (copyInit && copyInit.body) {
+      body = copyInit.body;
+      copyInit.body = undefined;
     }
 
-    const request = new Request(input, init);
+    const request = new Request(input, copyInit);
     if (body) {
-      init.body = body;
+      copyInit.body = body;
     }
 
     const url = request.url;
@@ -80,7 +84,7 @@ export function instrumentFetch() {
     };
 
     addCommonBeaconProperties(beacon);
-    addGraphQlProperties(beacon, input, init);
+    addGraphQlProperties(beacon, input, copyInit);
 
     const spanAndTraceId = generateUniqueId();
     const setBackendCorrelationHeaders = isSameOrigin(url) || isAllowedOrigin(url);
@@ -93,19 +97,17 @@ export function instrumentFetch() {
     beacon['bc'] = setBackendCorrelationHeaders ? 1 : 0;
 
     if (setBackendCorrelationHeaders) {
-      if (init && init.headers) {
-        if (!(init.headers instanceof Headers)) {
-          init.headers = new Headers(init.headers);
-        }
-        addCorrelationHttpHeaders(init.headers.append, init.headers, spanAndTraceId);
+      if (copyInit && copyInit.headers) {
+        copyInit.headers = new Headers(copyInit.headers);
+        addCorrelationHttpHeaders(copyInit.headers.append, copyInit.headers, spanAndTraceId);
       } else if (input instanceof Request) {
         addCorrelationHttpHeaders(request.headers.append, request.headers, spanAndTraceId);
       } else {
-        if (!init) {
-          init = {};
+        if (!copyInit) {
+          copyInit = {};
         }
-        init.headers = new Headers();
-        addCorrelationHttpHeaders(init.headers.append, init.headers, spanAndTraceId);
+        copyInit.headers = new Headers();
+        addCorrelationHttpHeaders(copyInit.headers.append, copyInit.headers, spanAndTraceId);
       }
     }
 
@@ -127,7 +129,7 @@ export function instrumentFetch() {
     });
     performanceObserver.onBeforeResourceRetrieval();
 
-    return originalFetch(input instanceof Request ? request : input, init)
+    return originalFetch(input instanceof Request ? request : input, copyInit)
       .then(function(response) {
         beacon['st'] = response.status;
         try {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "@babel/plugin-transform-flow-strip-types": "^7.0.0",
     "@babel/plugin-transform-modules-commonjs": "^7.0.0",
     "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+    "@rollup/plugin-commonjs": "^11.1.0",
     "@rollup/plugin-node-resolve": "^7.1.3",
+    "@types/object-assign": "^4.0.30",
     "apollo-server-express": "^2.14.2",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^24.8.0",
@@ -63,6 +65,7 @@
     "webdriver-manager": "^12.1.8"
   },
   "dependencies": {
+    "object-assign": "^4.1.1",
     "web-vitals": "1.1.1"
   }
 }

--- a/protractor.saucelabs.config.js
+++ b/protractor.saucelabs.config.js
@@ -14,7 +14,7 @@ exports.config = {
     newSaucelabsCapability('safari', '11.0', 'macOS 10.12'),
     newSaucelabsCapability('safari', '11.1', 'macOS 10.13'),
     newSaucelabsCapability('firefox', '78.0', 'Windows 7'),
-    newSaucelabsCapability('firefox', '59.0', 'Windows 10'),
+    newSaucelabsCapability('firefox', '58.0', 'Windows 11'),
     newSaucelabsCapability('chrome', '48.0', 'Windows 10'),
     newSaucelabsCapability('chrome', '54.0', 'OS X 10.11'),
     newSaucelabsCapability('chrome', '65.0', 'OS X 10.11')

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,7 @@ const replace = require('rollup-plugin-replace');
 const babel = require('rollup-plugin-babel');
 const path = require('path');
 const fs = require('fs');
+import commonjs from '@rollup/plugin-commonjs';
 
 const secureWebVitalsLoader = require('./secureWebVitalsLoader');
 
@@ -22,6 +23,7 @@ export default {
       exclude: 'node_modules/**',
       plugins: getPlugins()
     }),
+    commonjs(),
     secureWebVitalsLoader(),
     replace({
       DEBUG: JSON.stringify(isDebugBuild)

--- a/test/e2e/05_fetch/fetchWithCsrfToken.html
+++ b/test/e2e/05_fetch/fetchWithCsrfToken.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>fetch test</title>
+  <script src="/e2e/initializer.js"></script>
+  <script crossorigin="anonymous" defer src="/target/eum.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.js"></script>
+</head>
+<body>
+  <input id="btn1" type="button" value="complex fetch with csrf" onclick=complexFetch />
+
+  <div id="result"></div>
+
+
+  <script>
+    const fetchOptions = {
+      credentials: 'same-origin',
+      headers: {
+        'Buddy': 'hello world',
+        'X-Requested-With': 'SuperMan'
+      }
+    }
+
+    // async function complexFetch() {
+    //   const result = await fetch('/ajax', defaultFetchOptions);
+
+    //   const finalFetchOptions = {...defaultFetchOptions}
+    //   finalFetchOptions.headers['X-CSRF-Token'] = 'this-is-a-csrf-token';
+    //   const response = await fetch('/ajax', {body:'{"k":"v"}', method:'POST', ...finalFetchOptions})
+    //   $('#result').text(await response.text());
+    // }
+    // document.getElementById("btn1").addEventListener('click', complexFetch);
+
+    $(window).on('load', function() {
+      setTimeout(function() {
+        if (self.fetch) {
+          fetch('/ajax', fetchOptions)
+          .then(function() {
+            fetchOptions.headers['X-CSRF-Token'] = 'this-is-a-csrf-token';
+            fetchOptions.body = new FormData();
+            fetchOptions.method = 'POST';
+            return fetch('/ajax', fetchOptions)
+          })
+          .then(response => response.text())
+          .then(result => $('#result').text(result))
+          .catch(error => $('#result').text(error));
+        } else {
+            $('#result').text('The Fetch API is not supported by this browser.');
+        }
+      }, 100);
+    });
+  </script>
+</body>
+</html>

--- a/test/e2e/05_fetch/fetchWithCsrfToken.html
+++ b/test/e2e/05_fetch/fetchWithCsrfToken.html
@@ -8,43 +8,67 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.js"></script>
 </head>
 <body>
-  <input id="btn1" type="button" value="complex fetch with csrf" onclick=complexFetch />
 
   <div id="result"></div>
 
 
   <script>
-    const fetchOptions = {
+    eum('captureHeaders', [/test-header/i, /x-instana-l/i]);
+    const fetchOptions1 = {
       credentials: 'same-origin',
       headers: {
-        'Buddy': 'hello world',
-        'X-Requested-With': 'SuperMan'
+        'test-header': 'a'
       }
     }
 
-    // async function complexFetch() {
-    //   const result = await fetch('/ajax', defaultFetchOptions);
+    const fetchOptions2 = {
+      credentials: 'same-origin',
+      headers: [["test-header", "b"]]
+    }
 
-    //   const finalFetchOptions = {...defaultFetchOptions}
-    //   finalFetchOptions.headers['X-CSRF-Token'] = 'this-is-a-csrf-token';
-    //   const response = await fetch('/ajax', {body:'{"k":"v"}', method:'POST', ...finalFetchOptions})
-    //   $('#result').text(await response.text());
-    // }
-    // document.getElementById("btn1").addEventListener('click', complexFetch);
+    const headerObject = new Headers();
+    headerObject.append("test-header", "c");
+    const fetchOptions3 = {
+      credentials: 'same-origin',
+      headers: headerObject
+    }
 
     $(window).on('load', function() {
       setTimeout(function() {
         if (self.fetch) {
-          fetch('/ajax', fetchOptions)
+          fetch('/ajax', fetchOptions1)
           .then(function() {
-            fetchOptions.headers['X-CSRF-Token'] = 'this-is-a-csrf-token';
-            fetchOptions.body = new FormData();
-            fetchOptions.method = 'POST';
-            return fetch('/ajax', fetchOptions)
+            fetchOptions1.headers['X-CSRF-Token'] = 'this-is-a-csrf-token';
+            fetchOptions1.body = new FormData();
+            fetchOptions1.method = 'POST';
+            return fetch('/ajax', fetchOptions1)
           })
           .then(response => response.text())
           .then(result => $('#result').text(result))
           .catch(error => $('#result').text(error));
+
+          fetch('/ajax', fetchOptions2)
+          .then(function() {
+            fetchOptions2.headers.push(["X-CSRF-Token", "this-is-a-csrf-token"]);
+            fetchOptions2.body = new FormData();
+            fetchOptions2.method = 'POST';
+            return fetch('/ajax', fetchOptions2)
+          })
+          .then(response => response.text())
+          .then(result => $('#result').text(result))
+          .catch(error => $('#result').text(error));
+
+          fetch('/ajax', fetchOptions3)
+          .then(function() {
+            fetchOptions3.headers.append("X-CSRF-Token", "this-is-a-csrf-token");
+            fetchOptions3.body = new FormData();
+            fetchOptions3.method = 'POST';
+            return fetch('/ajax', fetchOptions3)
+          })
+          .then(response => response.text())
+          .then(result => $('#result').text(result))
+          .catch(error => $('#result').text(error));
+
         } else {
             $('#result').text('The Fetch API is not supported by this browser.');
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -939,6 +939,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/plugin-commonjs@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "@rollup/plugin-commonjs@npm:11.1.0"
+  dependencies:
+    "@rollup/pluginutils": ^3.0.8
+    commondir: ^1.0.1
+    estree-walker: ^1.0.1
+    glob: ^7.1.2
+    is-reference: ^1.1.2
+    magic-string: ^0.25.2
+    resolve: ^1.11.0
+  peerDependencies:
+    rollup: ^1.20.0||^2.0.0
+  checksum: 6349c946b2cbdaf2a47b56da3ac6f4f1105cf02520cd945da15d250a2b1c0d3501e9274bf52d0d419ab55dec9c89cd9d9b2fc9ffc0a57bf89a39eb741c298c72
+  languageName: node
+  linkType: hard
+
 "@rollup/plugin-node-resolve@npm:^7.1.3":
   version: 7.1.3
   resolution: "@rollup/plugin-node-resolve@npm:7.1.3"
@@ -1302,6 +1319,13 @@ __metadata:
   version: 2.4.0
   resolution: "@types/normalize-package-data@npm:2.4.0"
   checksum: fd22ba86a186a033dbe173840fd2ad091032be6d48163198869d058821acca7373d9f39cfd0caf42f3b92bc737723814fe1b4e9e90eacaa913836610aa197d3b
+  languageName: node
+  linkType: hard
+
+"@types/object-assign@npm:^4.0.30":
+  version: 4.0.30
+  resolution: "@types/object-assign@npm:4.0.30"
+  checksum: 24e0471ddcd578b7ea72d5174e9cd6b68d78b5fa00f9f48cee38713c0e2886c6c3478c53c04d0508d16deb4370eed71ed0bb1f5b9aaa406e61f07ffed5da1d3b
   languageName: node
   linkType: hard
 
@@ -2793,6 +2817,13 @@ __metadata:
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: ab8c07884e42c3a8dbc5dd9592c606176c7eb5c1ca5ff274bcf907039b2c41de3626f684ea75ccf4d361ba004bbaff1f577d5384c155f3871e456bdf27becf9e
+  languageName: node
+  linkType: hard
+
+"commondir@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "commondir@npm:1.0.1"
+  checksum: 59715f2fc456a73f68826285718503340b9f0dd89bfffc42749906c5cf3d4277ef11ef1cca0350d0e79204f00f1f6d83851ececc9095dc88512a697ac0b9bdcb
   languageName: node
   linkType: hard
 
@@ -4981,6 +5012,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-core-module@npm:^2.9.0":
+  version: 2.11.0
+  resolution: "is-core-module@npm:2.11.0"
+  dependencies:
+    has: ^1.0.3
+  checksum: f96fd490c6b48eb4f6d10ba815c6ef13f410b0ba6f7eb8577af51697de523e5f2cd9de1c441b51d27251bf0e4aebc936545e33a5d26d5d51f28d25698d4a8bab
+  languageName: node
+  linkType: hard
+
 "is-data-descriptor@npm:^0.1.4":
   version: 0.1.4
   resolution: "is-data-descriptor@npm:0.1.4"
@@ -5170,6 +5210,15 @@ __metadata:
   version: 1.0.0
   resolution: "is-potential-custom-element-name@npm:1.0.0"
   checksum: 39084c1e357f2adf0cb9843cabd3c1ac770c9da14addbfd4e5a0243877eb084d9f3446e40c53970fdb8ea9c07e95659d694a0c4c6c4aa7a3da3f3e108212984f
+  languageName: node
+  linkType: hard
+
+"is-reference@npm:^1.1.2":
+  version: 1.2.1
+  resolution: "is-reference@npm:1.2.1"
+  dependencies:
+    "@types/estree": "*"
+  checksum: e7b48149f8abda2c10849ea51965904d6a714193d68942ad74e30522231045acf06cbfae5a4be2702fede5d232e61bf50b3183acdc056e6e3afe07fcf4f4b2bc
   languageName: node
   linkType: hard
 
@@ -6907,7 +6956,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-assign@npm:^4, object-assign@npm:^4.0.1":
+"object-assign@npm:^4, object-assign@npm:^4.0.1, object-assign@npm:^4.1.1":
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: fcc6e4ea8c7fe48abfbb552578b1c53e0d194086e2e6bbbf59e0a536381a292f39943c6e9628af05b5528aa5e3318bb30d6b2e53cadaf5b8fe9e12c4b69af23f
@@ -7229,7 +7278,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-parse@npm:^1.0.6":
+"path-parse@npm:^1.0.6, path-parse@npm:^1.0.7":
   version: 1.0.7
   resolution: "path-parse@npm:1.0.7"
   checksum: 49abf3d81115642938a8700ec580da6e830dde670be21893c62f4e10bd7dd4c3742ddc603fe24f898cba7eb0c6bc1777f8d9ac14185d34540c6d4d80cd9cae8a
@@ -7873,6 +7922,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve@npm:^1.11.0":
+  version: 1.22.1
+  resolution: "resolve@npm:1.22.1"
+  dependencies:
+    is-core-module: ^2.9.0
+    path-parse: ^1.0.7
+    supports-preserve-symlinks-flag: ^1.0.0
+  bin:
+    resolve: bin/resolve
+  checksum: 07af5fc1e81aa1d866cbc9e9460fbb67318a10fa3c4deadc35c3ad8a898ee9a71a86a65e4755ac3195e0ea0cfbe201eb323ebe655ce90526fd61917313a34e4e
+  languageName: node
+  linkType: hard
+
 "resolve@npm:~1.1.7":
   version: 1.1.7
   resolution: "resolve@npm:1.1.7"
@@ -7887,6 +7949,19 @@ __metadata:
     is-core-module: ^2.2.0
     path-parse: ^1.0.6
   checksum: a0dd7d16a8e47af23afa9386df2dff10e3e0debb2c7299a42e581d9d9b04d7ad5d2c53f24f1e043f7b3c250cbdc71150063e53d0b6559683d37f790b7c8c3cd5
+  languageName: node
+  linkType: hard
+
+"resolve@patch:resolve@^1.11.0#~builtin<compat/resolve>":
+  version: 1.22.1
+  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
+  dependencies:
+    is-core-module: ^2.9.0
+    path-parse: ^1.0.7
+    supports-preserve-symlinks-flag: ^1.0.0
+  bin:
+    resolve: bin/resolve
+  checksum: 5656f4d0bedcf8eb52685c1abdf8fbe73a1603bb1160a24d716e27a57f6cecbe2432ff9c89c2bd57542c3a7b9d14b1882b73bfe2e9d7849c9a4c0b8b39f02b8b
   languageName: node
   linkType: hard
 
@@ -8008,7 +8083,9 @@ __metadata:
     "@babel/plugin-transform-flow-strip-types": ^7.0.0
     "@babel/plugin-transform-modules-commonjs": ^7.0.0
     "@babel/plugin-transform-shorthand-properties": ^7.0.0
+    "@rollup/plugin-commonjs": ^11.1.0
     "@rollup/plugin-node-resolve": ^7.1.3
+    "@types/object-assign": ^4.0.30
     apollo-server-express: ^2.14.2
     babel-eslint: ^10.0.1
     babel-jest: ^24.8.0
@@ -8024,6 +8101,7 @@ __metadata:
     husky: ^0.11.9
     jest: ^26.6.3
     multiparty: ^4.2.3
+    object-assign: ^4.1.1
     prettier: ^1.18.2
     pretty-bytes-cli: ^3.0.0
     protractor: ^7.0.0
@@ -8945,6 +9023,13 @@ __metadata:
     has-flag: ^4.0.0
     supports-color: ^7.0.0
   checksum: e4f430c870a258c9854b8bd7f166a9c1e76e3b851da84d4399d6a8f1d4a485e4ec36c16455dde80acf06c86e7c0a6df76ed22b6a4644a6ae3eced8616b3f21b5
+  languageName: node
+  linkType: hard
+
+"supports-preserve-symlinks-flag@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
+  checksum: 53b1e247e68e05db7b3808b99b892bd36fb096e6fba213a06da7fab22045e97597db425c724f2bbd6c99a3c295e1e73f3e4de78592289f38431049e1277ca0ae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**WHY:**
In some rare cases, a global variable is passed through as options of Fetch API. Then weasel modifies the type of headers in the parameter to Headers object during appending Instana correlation header. This case changes the type of a global variable and might cause conflict with further user cases.

Using a deep copy of options of Fetch and keeping the input one untouched is more safe.

**WHAT:**
Update hook of Fetch API to use deep copy of Fetch options.
