### PR TITLE
Deep copy init object of Fetch instead of modifying the original one

### DIFF
--- a/lib/hooks/Fetch.js
+++ b/lib/hooks/Fetch.js
@@ -38,15 +38,17 @@ export function instrumentFetch() {
       return originalFetch(input, init);
     }
 
+    let copyInit = init ? Object.assign({}, init) : init;
+
     let body;
-    if (init && init.body) {
-      body = init.body;
-      init.body = undefined;
+    if (copyInit && copyInit.body) {
+      body = copyInit.body;
+      copyInit.body = undefined;
     }
 
-    const request = new Request(input, init);
+    const request = new Request(input, copyInit);
     if (body) {
-      init.body = body;
+      copyInit.body = body;
     }
 
     const url = request.url;
@@ -80,7 +82,7 @@ export function instrumentFetch() {
     };
 
     addCommonBeaconProperties(beacon);
-    addGraphQlProperties(beacon, input, init);
+    addGraphQlProperties(beacon, input, copyInit);
 
     const spanAndTraceId = generateUniqueId();
     const setBackendCorrelationHeaders = isSameOrigin(url) || isAllowedOrigin(url);
@@ -93,19 +95,17 @@ export function instrumentFetch() {
     beacon['bc'] = setBackendCorrelationHeaders ? 1 : 0;
 
     if (setBackendCorrelationHeaders) {
-      if (init && init.headers) {
-        if (!(init.headers instanceof Headers)) {
-          init.headers = new Headers(init.headers);
-        }
-        addCorrelationHttpHeaders(init.headers.append, init.headers, spanAndTraceId);
+      if (copyInit && copyInit.headers) {
+        copyInit.headers = new Headers(copyInit.headers);
+        addCorrelationHttpHeaders(copyInit.headers.append, copyInit.headers, spanAndTraceId);
       } else if (input instanceof Request) {
         addCorrelationHttpHeaders(request.headers.append, request.headers, spanAndTraceId);
       } else {
-        if (!init) {
-          init = {};
+        if (!copyInit) {
+          copyInit = {};
         }
-        init.headers = new Headers();
-        addCorrelationHttpHeaders(init.headers.append, init.headers, spanAndTraceId);
+        copyInit.headers = new Headers();
+        addCorrelationHttpHeaders(copyInit.headers.append, copyInit.headers, spanAndTraceId);
       }
     }
 
@@ -127,7 +127,7 @@ export function instrumentFetch() {
     });
     performanceObserver.onBeforeResourceRetrieval();
 
-    return originalFetch(input instanceof Request ? request : input, init)
+    return originalFetch(input instanceof Request ? request : input, copyInit)
       .then(function(response) {
         beacon['st'] = response.status;
         try {

--- a/protractor.saucelabs.config.js
+++ b/protractor.saucelabs.config.js
@@ -14,7 +14,7 @@ exports.config = {
     newSaucelabsCapability('safari', '11.0', 'macOS 10.12'),
     newSaucelabsCapability('safari', '11.1', 'macOS 10.13'),
     newSaucelabsCapability('firefox', '78.0', 'Windows 7'),
-    newSaucelabsCapability('firefox', '59.0', 'Windows 10'),
+    newSaucelabsCapability('firefox', '58.0', 'Windows 11'),
     newSaucelabsCapability('chrome', '48.0', 'Windows 10'),
     newSaucelabsCapability('chrome', '54.0', 'OS X 10.11'),
     newSaucelabsCapability('chrome', '65.0', 'OS X 10.11')

--- a/test/e2e/05_fetch/fetch.spec.js
+++ b/test/e2e/05_fetch/fetch.spec.js
@@ -631,6 +631,102 @@ describe('05_fetch', () => {
     });
   });
 
+  describe('05_fetchWithCsrfToken', () => {
+    beforeEach(() => {
+      browser.get(getE2ETestBaseUrl('05_fetch/fetchWithCsrfToken'));
+    });
+
+    it('must send csrf token in fetch requests', () => {
+      return whenFetchIsSupported(() =>
+        retry(() => {
+          return Promise.all([getBeacons(), getAjaxRequests(), getResultElementContent(), getCapabilities()])
+            .then(([beacons, ajaxRequests, result, capabilities]) => {
+              cexpect(beacons).to.have.lengthOf(7);
+              cexpect(ajaxRequests).to.have.lengthOf(6);
+
+              const ajaxGetBeacon = expectOneMatching(beacons, beacon => {
+                cexpect(beacon['l']).to.equal(getE2ETestBaseUrl('05_fetch/fetchWithCsrfToken'));
+                cexpect(beacon['ty']).to.equal('xhr');
+                cexpect(beacon['m']).to.equal('GET');
+                cexpect(beacon['u']).to.match(/^http:\/\/127\.0\.0\.1:8000\/ajax+$/);
+                cexpect(beacon['h_test-header']).to.equal('a');
+              });
+
+              const ajaxGetRequest = expectOneMatching(ajaxRequests, ajaxRequest => {
+                cexpect(ajaxRequest.url).to.match(/^\/ajax+$/);
+                cexpect(ajaxRequest.method).to.equal('GET');
+                //original header is passed through
+                cexpect(ajaxRequest.headers['test-header']).to.equal('a');
+              });
+
+              const ajaxPostRequest = expectOneMatching(ajaxRequests, ajaxRequest => {
+                cexpect(ajaxRequest.url).to.match(/^\/ajax+$/);
+                cexpect(ajaxRequest.method).to.equal('POST');
+                cexpect(ajaxRequest.headers['x-csrf-token']).to.equal('this-is-a-csrf-token');
+                //original header is untouched.
+                cexpect(ajaxRequest.headers['test-header']).to.equal('a');
+              });
+
+              cexpect(ajaxGetRequest.headers['x-instana-t']).to.equal(ajaxGetBeacon.t);
+              //instana correltion header is not attached to original headers.
+              cexpect(ajaxPostRequest.headers['x-instana-t']).to.not.equal(ajaxGetBeacon.t);
+
+              const ajaxGetBeacon2 = expectOneMatching(beacons, beacon => {
+                cexpect(beacon['l']).to.equal(getE2ETestBaseUrl('05_fetch/fetchWithCsrfToken'));
+                cexpect(beacon['ty']).to.equal('xhr');
+                cexpect(beacon['m']).to.equal('GET');
+                cexpect(beacon['u']).to.match(/^http:\/\/127\.0\.0\.1:8000\/ajax+$/);
+                cexpect(beacon['h_test-header']).to.equal('b');
+              });
+
+              const ajaxGetRequest2 = expectOneMatching(ajaxRequests, ajaxRequest => {
+                cexpect(ajaxRequest.method).to.equal('GET');
+                //original header is passed through
+                cexpect(ajaxRequest.headers['test-header']).to.equal('b');
+              });
+
+              const ajaxPostRequest2 = expectOneMatching(ajaxRequests, ajaxRequest => {
+                cexpect(ajaxRequest.method).to.equal('POST');
+                cexpect(ajaxRequest.headers['x-csrf-token']).to.equal('this-is-a-csrf-token');
+                //original header is untouched.
+                cexpect(ajaxRequest.headers['test-header']).to.equal('b');
+              });
+
+              cexpect(ajaxGetRequest2.headers['x-instana-t']).to.equal(ajaxGetBeacon2.t);
+              //instana correltion header is not attached to original headers.
+              cexpect(ajaxPostRequest2.headers['x-instana-t']).to.not.equal(ajaxGetBeacon2.t);
+
+              const ajaxGetBeacon3 = expectOneMatching(beacons, beacon => {
+                cexpect(beacon['l']).to.equal(getE2ETestBaseUrl('05_fetch/fetchWithCsrfToken'));
+                cexpect(beacon['ty']).to.equal('xhr');
+                cexpect(beacon['m']).to.equal('GET');
+                cexpect(beacon['u']).to.match(/^http:\/\/127\.0\.0\.1:8000\/ajax+$/);
+                cexpect(beacon['h_test-header']).to.equal('c');
+              });
+
+              const ajaxGetRequest3 = expectOneMatching(ajaxRequests, ajaxRequest => {
+                cexpect(ajaxRequest.method).to.equal('GET');
+                //original header is passed through
+                cexpect(ajaxRequest.headers['test-header']).to.equal('c');
+              });
+
+              const ajaxPostRequest3 = expectOneMatching(ajaxRequests, ajaxRequest => {
+                cexpect(ajaxRequest.method).to.equal('POST');
+                cexpect(ajaxRequest.headers['x-csrf-token']).to.equal('this-is-a-csrf-token');
+                //original header is untouched.
+                cexpect(ajaxRequest.headers['test-header']).to.equal('c');
+              });
+
+              cexpect(ajaxGetRequest3.headers['x-instana-t']).to.equal(ajaxGetBeacon3.t);
+              //instana correltion header is not attached to original headers.
+              cexpect(ajaxPostRequest3.headers['x-instana-t']).to.not.equal(ajaxGetBeacon3.t);
+
+            });
+        })
+      );
+    });
+  });
+
   function whenFetchIsSupported(fn) {
     return whenConfigMatches(
       config => {

--- a/test/e2e/05_fetch/fetchWithCsrfToken.html
+++ b/test/e2e/05_fetch/fetchWithCsrfToken.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>fetch test</title>
+  <script src="/e2e/initializer.js"></script>
+  <script crossorigin="anonymous" defer src="/target/eum.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.js"></script>
+</head>
+<body>
+
+  <div id="result"></div>
+
+
+  <script>
+    eum('captureHeaders', [/test-header/i, /x-instana-l/i]);
+    const fetchOptions1 = {
+      credentials: 'same-origin',
+      headers: {
+        'test-header': 'a'
+      }
+    }
+
+    const fetchOptions2 = {
+      credentials: 'same-origin',
+      headers: [["test-header", "b"]]
+    }
+
+    let headerObject = new Headers();
+    headerObject.append("test-header", "c");
+    const fetchOptions3 = {
+      credentials: 'same-origin',
+      headers: headerObject
+    }
+
+    $(window).on('load', function() {
+      setTimeout(function() {
+        if (self.fetch) {
+          fetch('/ajax', fetchOptions1)
+          .then(function() {
+            fetchOptions1.headers['X-CSRF-Token'] = 'this-is-a-csrf-token';
+            fetchOptions1.body = new FormData();
+            fetchOptions1.method = 'POST';
+            return fetch('/ajax', fetchOptions1)
+          })
+          .then(response => response.text())
+          .then(result => $('#result').text(result))
+          .catch(error => $('#result').text(error));
+
+          fetch('/ajax', fetchOptions2)
+          .then(function() {
+            fetchOptions2.headers.push(["X-CSRF-Token", "this-is-a-csrf-token"]);
+            fetchOptions2.body = new FormData();
+            fetchOptions2.method = 'POST';
+            return fetch('/ajax', fetchOptions2)
+          })
+          .then(response => response.text())
+          .then(result => $('#result').text(result))
+          .catch(error => $('#result').text(error));
+
+          fetch('/ajax', fetchOptions3)
+          .then(function() {
+            fetchOptions3.headers.append("X-CSRF-Token", "this-is-a-csrf-token");
+            fetchOptions3.body = new FormData();
+            fetchOptions3.method = 'POST';
+            return fetch('/ajax', fetchOptions3)
+          })
+          .then(response => response.text())
+          .then(result => $('#result').text(result))
+          .catch(error => $('#result').text(error));
+
+        } else {
+            $('#result').text('The Fetch API is not supported by this browser.');
+        }
+      }, 100);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
**WHY:**
In some rare cases, a global variable is passed through as options of Fetch API. Then weasel modifies the type of headers in the parameter to Headers object during appending Instana correlation header. This case changes the type of a global variable and might cause conflict with further user cases.

Using a deep copy of options of Fetch and keeping the input one untouched is more safe.

**WHAT:**
Update hook of Fetch API to use deep copy of Fetch options.
