### PR TITLE
New API webvitalsInCustomEvent to track webvitals in custom event.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,21 +14,9 @@ module.exports = {
     ErrorLike: false
   },
   rules: {
-    indent: [
-      'error',
-      2
-    ],
-    'linebreak-style': [
-      'error',
-      'unix'
-    ],
-    quotes: [
-      'error',
-      'single'
-    ],
-    semi: [
-      'error',
-      'always'
-    ]
+    indent: ['error', 2, {SwitchCase: 1}],
+    'linebreak-style': ['error', 'unix'],
+    quotes: ['error', 'single'],
+    semi: ['error', 'always']
   }
 };

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,6 @@
 {
   "printWidth": 120,
-  "singleQuote": true
+  "singleQuote": true,
+  "quoteProps": "preserve",
+  "bracketSpacing": false
 }

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -10,126 +10,130 @@ import vars from './vars';
 
 export function processCommand(command: any[]): any {
   switch (command[0]) {
-  case 'apiKey':
-    vars.apiKey = command[1];
-    break;
-  case 'key':
-    vars.apiKey = command[1];
-    break;
-  case 'reportingUrl':
-    vars.reportingUrl = command[1];
-    break;
-  case 'meta':
-    vars.meta[command[1]] = command[2];
-    break;
-  case 'traceId':
-    vars.pageLoadBackendTraceId = command[1];
-    break;
-  case 'ignoreUrls':
-    if (DEBUG) {
-      validateRegExpArray('ignoreUrls', command[1]);
-    }
-    vars.ignoreUrls = command[1];
-    break;
-  case 'ignoreErrorMessages':
-    if (DEBUG) {
-      validateRegExpArray('ignoreErrorMessages', command[1]);
-    }
-    vars.ignoreErrorMessages = command[1];
-    break;
-  case 'allowedOrigins':
-  case 'whitelistedOrigins': // a deprecated alias for allowedOrigins
-    if (DEBUG) {
-      validateRegExpArray('allowedOrigins', command[1]);
-    }
-    vars.allowedOrigins = command[1];
-    break;
-  case 'ignoreUserTimings':
-    if (DEBUG) {
-      validateRegExpArray('ignoreUserTimings', command[1]);
-    }
-    vars.ignoreUserTimings = command[1];
-    break;
-  case 'xhrTransmissionTimeout':
-    vars.xhrTransmissionTimeout = command[1];
-    break;
-  case 'page':
-    setPage(command[1]);
-    break;
-  case 'ignorePings':
-    vars.ignorePings = command[1];
-    break;
-  case 'reportError':
-    reportError(command[1], command[2]);
-    break;
-  case 'wrapEventHandlers':
-    vars.wrapEventHandlers = command[1];
-    break;
-  case 'wrapTimers':
-    vars.wrapTimers = command[1];
-    break;
-  case 'getPageLoadId':
-    return vars.pageLoadTraceId;
-  case 'user':
-    if (command[1]) {
-      vars.userId = String(command[1]).substring(0, 128);
-    }
-    if (command[2]) {
-      vars.userName = String(command[2]).substring(0, 128);
-    }
-    if (command[3]) {
-      vars.userEmail = String(command[3]).substring(0, 128);
-    }
-    break;
-  case 'reportEvent':
-    reportCustomEvent(command[1], command[2]);
-    break;
-  case 'beaconBatchingTime':
-    vars.beaconBatchingTime = command[1];
-    break;
-  case 'maxWaitForResourceTimingsMillis':
-    vars.maxWaitForResourceTimingsMillis = command[1];
-    break;
-  case 'maxMaitForPageLoadMetricsMillis':
-    vars.maxMaitForPageLoadMetricsMillis = command[1];
-    break;
-  case 'trackSessions':
-    trackSessions(command[1], command[2]);
-    break;
-  case 'terminateSession':
-    terminateSession();
-    break;
-  case 'urlsToCheckForGraphQlInsights':
-    if (DEBUG) {
-      validateRegExpArray('urlsToCheckForGraphQlInsights', command[1]);
-    }
-    vars.urlsToCheckForGraphQlInsights = command[1];
-    break;
-  case 'secrets':
-    if (DEBUG) {
-      validateRegExpArray('secrets', command[1]);
-    }
-    vars.secrets = command[1];
-    break;
-  case 'captureHeaders':
-    if (DEBUG) {
-      validateRegExpArray('captureHeaders', command[1]);
-    }
-    vars.headersToCapture = command[1];
-    break;
-  case 'debug':
-    // Not using an if (DEBUG) {…} wrapper nor the integrated logging
-    // facilities to keep the end-user impact as low as possible.
-    console.log({vars});
-    break;
-  case 'reportingBackends':
-    processReportingBackends(command[1]);
-    break;
-  default:
-    if (DEBUG) {
-      warn('Unsupported command: ' + command[0]);
-    }
-    break;
+    case 'apiKey':
+      vars.apiKey = command[1];
+      break;
+    case 'key':
+      vars.apiKey = command[1];
+      break;
+    case 'reportingUrl':
+      vars.reportingUrl = command[1];
+      break;
+    case 'meta':
+      vars.meta[command[1]] = command[2];
+      break;
+    case 'traceId':
+      vars.pageLoadBackendTraceId = command[1];
+      break;
+    case 'ignoreUrls':
+      if (DEBUG) {
+        validateRegExpArray('ignoreUrls', command[1]);
+      }
+      vars.ignoreUrls = command[1];
+      break;
+    case 'ignoreErrorMessages':
+      if (DEBUG) {
+        validateRegExpArray('ignoreErrorMessages', command[1]);
+      }
+      vars.ignoreErrorMessages = command[1];
+      break;
+    case 'allowedOrigins':
+    case 'whitelistedOrigins': // a deprecated alias for allowedOrigins
+      if (DEBUG) {
+        validateRegExpArray('allowedOrigins', command[1]);
+      }
+      vars.allowedOrigins = command[1];
+      break;
+    case 'ignoreUserTimings':
+      if (DEBUG) {
+        validateRegExpArray('ignoreUserTimings', command[1]);
+      }
+      vars.ignoreUserTimings = command[1];
+      break;
+    case 'xhrTransmissionTimeout':
+      vars.xhrTransmissionTimeout = command[1];
+      break;
+    case 'page':
+      setPage(command[1]);
+      break;
+    case 'ignorePings':
+      vars.ignorePings = command[1];
+      break;
+    case 'reportError':
+      reportError(command[1], command[2]);
+      break;
+    case 'wrapEventHandlers':
+      vars.wrapEventHandlers = command[1];
+      break;
+    case 'wrapTimers':
+      vars.wrapTimers = command[1];
+      break;
+    case 'getPageLoadId':
+      return vars.pageLoadTraceId;
+    case 'user':
+      if (command[1]) {
+        vars.userId = String(command[1]).substring(0, 128);
+      }
+      if (command[2]) {
+        vars.userName = String(command[2]).substring(0, 128);
+      }
+      if (command[3]) {
+        vars.userEmail = String(command[3]).substring(0, 128);
+      }
+      break;
+    case 'reportEvent':
+      reportCustomEvent(command[1], command[2]);
+      break;
+    case 'beaconBatchingTime':
+      vars.beaconBatchingTime = command[1];
+      break;
+    case 'maxWaitForResourceTimingsMillis':
+      vars.maxWaitForResourceTimingsMillis = command[1];
+      break;
+    case 'maxMaitForPageLoadMetricsMillis':
+      vars.maxMaitForPageLoadMetricsMillis = command[1];
+      break;
+    case 'trackSessions':
+      trackSessions(command[1], command[2]);
+      break;
+    case 'terminateSession':
+      terminateSession();
+      break;
+    case 'urlsToCheckForGraphQlInsights':
+      if (DEBUG) {
+        validateRegExpArray('urlsToCheckForGraphQlInsights', command[1]);
+      }
+      vars.urlsToCheckForGraphQlInsights = command[1];
+      break;
+    case 'secrets':
+      if (DEBUG) {
+        validateRegExpArray('secrets', command[1]);
+      }
+      vars.secrets = command[1];
+      break;
+    case 'captureHeaders':
+      if (DEBUG) {
+        validateRegExpArray('captureHeaders', command[1]);
+      }
+      vars.headersToCapture = command[1];
+      break;
+    case 'debug':
+      // Not using an if (DEBUG) {…} wrapper nor the integrated logging
+      // facilities to keep the end-user impact as low as possible.
+      // eslint-disable-next-line no-console
+      console.log({vars});
+      break;
+    case 'reportingBackends':
+      processReportingBackends(command[1]);
+      break;
+    case 'webvitalsInCustomEvent':
+      vars.webvitalsInCustomEvent = command[1];
+      break;
+    default:
+      if (DEBUG) {
+        warn('Unsupported command: ' + command[0]);
+      }
+      break;
   }
 }
 

--- a/lib/customEvents.js
+++ b/lib/customEvents.js
@@ -53,16 +53,19 @@ function enrich(beacon: CustomEventBeacon, opts: CustomEventOptions) {
 
   if (typeof opts['duration'] === 'number' && !isNaN(opts['duration'])) {
     beacon['d'] = opts['duration'];
+    // add Math.round since duration could be a float
     // $FlowFixMe: We know that both properties are numbers. Flow thinks they are strings because we access them via […].
-    beacon['ts'] = beacon['ts'] - opts['duration'];
+    beacon['ts'] = Math.round(beacon['ts'] - opts['duration']);
   }
 
   if (typeof opts['timestamp'] === 'number' && !isNaN(opts['timestamp'])) {
     beacon['ts'] = opts['timestamp'];
   }
 
-  if (typeof opts['backendTraceId'] === 'string'
-    && (opts['backendTraceId'].length === 16 || opts['backendTraceId'].length === 32)) {
+  if (
+    typeof opts['backendTraceId'] === 'string' &&
+    (opts['backendTraceId'].length === 16 || opts['backendTraceId'].length === 32)
+  ) {
     beacon['bt'] = opts['backendTraceId'];
   }
 

--- a/lib/vars.js
+++ b/lib/vars.js
@@ -338,7 +338,7 @@ const defaultVars: {
   secrets: [/key/i, /password/i, /secret/i],
   headersToCapture: [],
   reportingBackends: [],
-  webvitalsInCustomEvent: true
+  webvitalsInCustomEvent: false
 };
 
 export default defaultVars;

--- a/lib/vars.js
+++ b/lib/vars.js
@@ -278,8 +278,16 @@ const defaultVars: {
   // Changes backends which beacons will be send.
   // Change via
   // eum('reportingBackends', [{reportingUrl: '//eum.example.com', key: 'key'}]);
-  reportingBackends: ReportingBackend[]
+  reportingBackends: ReportingBackend[],
 
+  // Whether or not weasel should generate dedicated custom events on webvital metrics
+  // these custom events is more reliable than webvitals in PageLoad beacon, as we
+  // will not wait for so long in PageLoad beacon, with custom events, these metrics
+  // could be reported on demand at any time.
+  //
+  // Set via:
+  // eum('webvitalsInCustomEvent', false)
+  webvitalsInCustomEvent: boolean
 } = {
   nameOfLongGlobal: 'EumObject',
   trackingSnippetVersion: null,
@@ -312,7 +320,7 @@ const defaultVars: {
   sessionStorageKey: 'session',
   defaultSessionInactivityTimeoutMillis: 1000 * 60 * 60 * 3,
   defaultSessionTerminationTimeoutMillis: 1000 * 60 * 60 * 6,
-  maxAllowedSessionTimeoutMillis:  1000 * 60 * 60 * 24,
+  maxAllowedSessionTimeoutMillis: 1000 * 60 * 60 * 24,
   // The default ignore rules cover specific React and Angular patterns:
   //
   // React has a whole lot of user timings. Luckily all of them start with
@@ -329,8 +337,8 @@ const defaultVars: {
   urlsToCheckForGraphQlInsights: [/\/graphql/i],
   secrets: [/key/i, /password/i, /secret/i],
   headersToCapture: [],
-  reportingBackends: []
-
+  reportingBackends: [],
+  webvitalsInCustomEvent: true
 };
 
 export default defaultVars;

--- a/lib/webVitals.js
+++ b/lib/webVitals.js
@@ -19,7 +19,7 @@ function reportExtraMetrics(metric: Metric) {
   }
 
   // $FlowFixMe: Flow cannot detect that this is a proper usage of the function. We have to write it this way because of the Closure compiler advanced mode.
-  reportCustomEvent('webvitals-' + metric.name, {
+  reportCustomEvent('instana-webvitals-' + metric.name, {
     'duration': metric.value,
     'meta': {
       'id': metric.id

--- a/lib/webVitals.js
+++ b/lib/webVitals.js
@@ -1,13 +1,25 @@
 // @flow
 
 // $FlowFixMe Flow doesn't find the file. Let's ignore this for now.
-import { getCLS, getLCP, getFID } from 'web-vitals/dist/web-vitals.js';
+import {getCLS, getLCP, getFID} from 'web-vitals/dist/web-vitals.js';
 import type {PageLoadBeacon} from './types';
+import {reportCustomEvent} from './customEvents';
 
 interface Metric {
-  name: 'CLS' | 'FID' | 'LCP',
+  name: 'CLS' | 'FID' | 'LCP';
 
-  value: number
+  value: number;
+  id?: string;
+}
+
+function reportExtraMetrics(metric: Metric) {
+  // $FlowFixMe: Flow cannot detect that this is a proper usage of the function. We have to write it this way because of the Closure compiler advanced mode.
+  reportCustomEvent('webvitals-' + metric.name, {
+    'duration': metric.value,
+    'meta': {
+      'id': metric.id
+    }
+  });
 }
 
 export function addWebVitals(beacon: PageLoadBeacon) {
@@ -23,11 +35,11 @@ export function addWebVitals(beacon: PageLoadBeacon) {
 
   function onMetric(metric: Metric) {
     beacon['t_' + metric.name.toLocaleLowerCase()] = Math.round(metric.value);
+    reportExtraMetrics(metric);
   }
 
   function onMetricWithoutRounding(metric: Metric) {
     beacon['t_' + metric.name.toLocaleLowerCase()] = metric.value;
+    reportExtraMetrics(metric);
   }
 }
-
-

--- a/lib/webVitals.js
+++ b/lib/webVitals.js
@@ -3,6 +3,7 @@
 // $FlowFixMe Flow doesn't find the file. Let's ignore this for now.
 import {getCLS, getLCP, getFID} from 'web-vitals/dist/web-vitals.js';
 import type {PageLoadBeacon} from './types';
+import {pageLoadStartTimestamp} from './timings';
 import {reportCustomEvent} from './customEvents';
 import vars from './vars';
 
@@ -20,6 +21,7 @@ function reportExtraMetrics(metric: Metric) {
 
   // $FlowFixMe: Flow cannot detect that this is a proper usage of the function. We have to write it this way because of the Closure compiler advanced mode.
   reportCustomEvent('instana-webvitals-' + metric.name, {
+    'timestamp': pageLoadStartTimestamp + Math.round(metric.value),
     'duration': metric.value,
     'meta': {
       'id': metric.id

--- a/lib/webVitals.js
+++ b/lib/webVitals.js
@@ -4,6 +4,7 @@
 import {getCLS, getLCP, getFID} from 'web-vitals/dist/web-vitals.js';
 import type {PageLoadBeacon} from './types';
 import {reportCustomEvent} from './customEvents';
+import vars from './vars';
 
 interface Metric {
   name: 'CLS' | 'FID' | 'LCP';
@@ -13,6 +14,10 @@ interface Metric {
 }
 
 function reportExtraMetrics(metric: Metric) {
+  if (!vars.webvitalsInCustomEvent) {
+    return;
+  }
+
   // $FlowFixMe: Flow cannot detect that this is a proper usage of the function. We have to write it this way because of the Closure compiler advanced mode.
   reportCustomEvent('webvitals-' + metric.name, {
     'duration': metric.value,

--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
   },
   "dependencies": {
     "object-assign": "^4.1.1",
-    "web-vitals": "1.1.1"
+    "web-vitals": "1.1.2"
   }
 }

--- a/protractor.local.config.js
+++ b/protractor.local.config.js
@@ -1,6 +1,20 @@
 /* eslint-env node */
 
+const chromeArgs = [
+  /*'--disable-web-security'*/
+];
+const proxy = process.env.HTTP_PROXY || process.env.http_proxy || process.env.HTTPS_PROXY || process.env.https_proxy;
+if (proxy) {
+  chromeArgs.push(`--proxy-server=${proxy}`);
+}
+
 exports.config = {
   seleniumAddress: 'http://localhost:4444/wd/hub',
-  specs: ['test/e2e/**/*.spec.js']
+  specs: ['test/e2e/**/*.spec.js'],
+  capabilities: {
+    'browserName': 'chrome',
+    'goog:chromeOptions': {
+      'args': chromeArgs
+    }
+  }
 };

--- a/test/e2e/12_webvitalsAsCustomEvent/webvitalsAsCustomEvent.html
+++ b/test/e2e/12_webvitalsAsCustomEvent/webvitalsAsCustomEvent.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>error test</title>
+
+  <script src="/e2e/initializer.js"></script>
+  <script>
+    eum('webvitalsInCustomEvent', true);
+  </script>
+  <script crossorigin="anonymous" defer src="/target/eum.min.js"></script>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+    integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css"
+    integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.js"></script>
+</head>
+
+<body>
+  <nav class="navbar navbar-default">
+    <div class="container-fluid">
+      <!-- Brand and toggle get grouped for better mobile display -->
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse"
+          data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+        <a class="navbar-brand" href="#">Instana</a>
+      </div>
+
+      <!-- Collect the nav links, forms, and other content for toggling -->
+      <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+        <ul class="nav navbar-nav">
+          <li class="active"><a href="#">WebVitals As Custom Events <span class="sr-only">(current)</span></a></li>
+          <li><a href="#" id="link1">Link</a></li>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
+              aria-expanded="false">Dropdown <span class="caret"></span></a>
+            <ul class="dropdown-menu">
+              <li><a href="#">Action</a></li>
+              <li><a href="#">Another action</a></li>
+              <li><a href="#">Something else here</a></li>
+              <li role="separator" class="divider"></li>
+              <li><a href="#">Separated link</a></li>
+              <li role="separator" class="divider"></li>
+              <li><a href="#">One more separated link</a></li>
+            </ul>
+          </li>
+        </ul>
+        <form class="navbar-form navbar-left">
+          <div class="form-group">
+            <input type="text" class="form-control" placeholder="Search" id="searchInput">
+          </div>
+          <button type="button" class="btn btn-default" id="searchButton">search</button>
+        </form>
+        <ul class="nav navbar-nav navbar-right">
+          <li><a href="#">...</a></li>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
+              aria-expanded="false">Dropdown <span class="caret"></span></a>
+            <ul class="dropdown-menu">
+              <li><a href="#">Action</a></li>
+              <li><a href="#">Another action</a></li>
+              <li><a href="#">Something else here</a></li>
+              <li role="separator" class="divider"></li>
+              <li><a href="#">Separated link</a></li>
+            </ul>
+          </li>
+        </ul>
+      </div><!-- /.navbar-collapse -->
+    </div><!-- /.container-fluid -->
+  </nav>
+
+  <button type="button" class="btn btn-default" id="button1">button1</button>
+  <button type="button" class="btn btn-default" id="button2">button2</button>
+  <button type="button" class="btn btn-default" id="button3">button3</button>
+
+  <div class="jumbotron" id="resultwrap" style="display: none">
+    <div class="media">
+      <div class="media-body">
+        <h2 class="media-heading" id="result">...</h4>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    $('#button3').on('click', function () {
+      $('#button1').show();
+    });
+    $('#button2').on('click', function () {
+      $('#button1').hide();
+    });
+
+    $(window).on("load", function () {
+      console.log("window loaded");
+      $('#link1').text('onLoad');
+      $('#button1').hide();
+
+      setTimeout(() => {
+        console.log("show result");
+        var longText = `Believing neglected so so allowance existence departure in. In design active temper be uneasy. Thirty for remove plenty regard you summer though. He preference connection astonished on of ye. Partiality on or continuing in particular principles as. Do believing oh disposing to supported allowance we.
+
+As absolute is by amounted repeated entirely ye returned. These ready timed enjoy might sir yet one since. Years drift never if could forty being no. On estimable dependent as suffering on my. Rank it long have sure in room what as he. Possession travelling sufficient yet our. Talked vanity looked in to. Gay perceive led believed endeavor. Rapturous no of estimable oh therefore direction up. Sons the ever not fine like eyes all sure.
+
+Sudden looked elinor off gay estate nor silent. Son read such next see the rest two. Was use extent old entire sussex. Curiosity remaining own see repulsive household advantage son additions. Supposing exquisite daughters eagerness why repulsive for. Praise turned it lovers be warmly by. Little do it eldest former be if.
+
+Society excited by cottage private an it esteems. Fully begin on by wound an. Girl rich in do up or both. At declared in as rejoiced of together. He impression collecting delightful unpleasant by prosperous as on. End too talent she object mrs wanted remove giving.
+
+Mr do raising article general norland my hastily. Its companions say uncommonly pianoforte favourable. Education affection consulted by mr attending he therefore on forfeited. High way more far feet kind evil play led. Sometimes furnished collected add for resources attention. Norland an by minuter enquire it general on towards forming. Adapted mrs totally company two yet conduct men.
+
+On it differed repeated wandered required in. Then girl neat why yet knew rose spot. Moreover property we he kindness greatest be oh striking laughter. In me he at collecting affronting principles apartments. Has visitor law attacks pretend you calling own excited painted. Contented attending smallness it oh ye unwilling. Turned favour man two but lovers. Suffer should if waited common person little oh. Improved civility graceful sex few smallest screened settling. Likely active her warmly has.
+
+Although moreover mistaken kindness me feelings do be marianne. Son over own nay with tell they cold upon are. Cordial village and settled she ability law herself. Finished why bringing but sir bachelor unpacked any thoughts. Unpleasing unsatiable particular inquietude did nor sir. Get his declared appetite distance his together now families. Friends am himself at on norland it viewing. Suspected elsewhere you belonging continued commanded she.
+
+Behaviour we improving at something to. Evil true high lady roof men had open. To projection considered it precaution an melancholy or. Wound young you thing worse along being ham. Dissimilar of favourable solicitude if sympathize middletons at. Forfeited up if disposing perfectly in an eagerness perceived necessary. Belonging sir curiosity discovery extremity yet forfeited prevailed own off. Travelling by introduced of mr terminated. Knew as miss my high hope quit. In curiosity shameless dependent knowledge up.
+
+Months on ye at by esteem desire warmth former. Sure that that way gave any fond now. His boy middleton sir nor engrossed affection excellent. Dissimilar compliment cultivated preference eat sufficient may. Well next door soon we mr he four. Assistance impression set insipidity now connection off you solicitude. Under as seems we me stuff those style at. Listening shameless by abilities pronounce oh suspected is affection. Next it draw in draw much bred.
+
+Consulted perpetual of pronounce me delivered. Too months nay end change relied who beauty wishes matter. Shew of john real park so rest we on. Ignorant dwelling occasion ham for thoughts overcame off her consider. Polite it elinor is depend. His not get talked effect worthy barton. Household shameless incommode at no objection behaviour. Especially do at he possession insensible sympathize boisterous it. Songs he on an widen me event truth. Certain law age brother sending amongst why covered. `;
+        $('#result').text(longText);
+        $('#resultwrap').show();
+      }, 3000);
+    });
+  </script>
+</body>
+
+</html>

--- a/test/e2e/12_webvitalsAsCustomEvent/webvitalsAsCustomEvent.spec.js
+++ b/test/e2e/12_webvitalsAsCustomEvent/webvitalsAsCustomEvent.spec.js
@@ -1,5 +1,5 @@
 const {registerTestServerHooks, getE2ETestBaseUrl, getBeacons} = require('../../server/controls');
-const {registerBaseHooks} = require('../base');
+const {registerBaseHooks, restartBrowser} = require('../base');
 const {retry, expectOneMatching} = require('../../util');
 
 const cexpect = require('chai').expect;
@@ -10,6 +10,9 @@ describe('12_webvitalsAsCustomEvent', () => {
 
   describe('webvitalsAsCustomEvent', () => {
     beforeEach(() => {
+      // webvital CLS does not work if following another test, so restart browser to cleanup all context
+      restartBrowser();
+
       browser.get(getE2ETestBaseUrl('12_webvitalsAsCustomEvent/webvitalsAsCustomEvent'));
       // wait for webvital metrics
       browser.sleep(5000);
@@ -19,9 +22,10 @@ describe('12_webvitalsAsCustomEvent', () => {
       element(by.id('button3')).click();
       browser.sleep(1000);
       element(by.id('button2')).click();
+      browser.sleep(1000);
     });
 
-    fit('must report web-vitals as custom events', () => {
+    it('must report web-vitals as custom events', () => {
       return retry(() => {
         return getBeacons().then(beacons => {
           const pageLoadBeacon = expectOneMatching(beacons, beacon => {

--- a/test/e2e/12_webvitalsAsCustomEvent/webvitalsAsCustomEvent.spec.js
+++ b/test/e2e/12_webvitalsAsCustomEvent/webvitalsAsCustomEvent.spec.js
@@ -1,0 +1,62 @@
+const {registerTestServerHooks, getE2ETestBaseUrl, getBeacons} = require('../../server/controls');
+const {registerBaseHooks} = require('../base');
+const {retry, expectOneMatching} = require('../../util');
+
+const cexpect = require('chai').expect;
+
+describe('12_webvitalsAsCustomEvent', () => {
+  registerTestServerHooks();
+  registerBaseHooks();
+
+  describe('webvitalsAsCustomEvent', () => {
+    beforeEach(() => {
+      browser.get(getE2ETestBaseUrl('12_webvitalsAsCustomEvent/webvitalsAsCustomEvent'));
+      // wait for webvital metrics
+      browser.sleep(5000);
+      element(by.id('searchInput')).sendKeys('hello');
+      element(by.id('searchButton')).click();
+      browser.sleep(1000);
+      element(by.id('button3')).click();
+      browser.sleep(1000);
+      element(by.id('button2')).click();
+    });
+
+    fit('must report web-vitals as custom events', () => {
+      return retry(() => {
+        return getBeacons().then(beacons => {
+          const pageLoadBeacon = expectOneMatching(beacons, beacon => {
+            cexpect(beacon.ty).to.equal('pl');
+          });
+
+          expectOneMatching(beacons, beacon => {
+            cexpect(beacon.ty).to.equal('cus');
+            cexpect(beacon.ts).to.be.a('string');
+            cexpect(parseFloat(beacon.d)).to.be.above(3000);
+            cexpect(beacon.n).to.equal('instana-webvitals-LCP');
+            cexpect(beacon.l).to.be.a('string');
+            cexpect(beacon.pl).to.equal(pageLoadBeacon.t);
+            cexpect(beacon.m_id).to.match(/^v\d+(-\d+)+$/);
+          });
+
+          expectOneMatching(beacons, beacon => {
+            cexpect(beacon.ty).to.equal('cus');
+            cexpect(beacon.ts).to.be.a('string');
+            cexpect(beacon.n).to.equal('instana-webvitals-FID');
+            cexpect(beacon.l).to.be.a('string');
+            cexpect(beacon.pl).to.equal(pageLoadBeacon.t);
+            cexpect(beacon.m_id).to.match(/^v\d+(-\d+)+$/);
+          });
+
+          expectOneMatching(beacons, beacon => {
+            cexpect(beacon.ty).to.equal('cus');
+            cexpect(beacon.ts).to.be.a('string');
+            cexpect(beacon.n).to.equal('instana-webvitals-CLS');
+            cexpect(beacon.l).to.be.a('string');
+            cexpect(beacon.pl).to.equal(pageLoadBeacon.t);
+            cexpect(beacon.m_id).to.match(/^v\d+(-\d+)+$/);
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/e2e/13_repeatedInjection/repeatedInjection.html
+++ b/test/e2e/13_repeatedInjection/repeatedInjection.html
@@ -1,0 +1,210 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Page 1</title>
+
+  <script src="/e2e/initializer.js"></script>
+  <script>
+    eum('webvitalsInCustomEvent', true);
+    eum('key', 'key1');
+
+    eum('reportEvent', 'myTestEvent1', {
+      duration: 11,
+      error: new Error('Testing 11'),
+      componentStack: 'a component stack'
+    });
+  </script>
+  <script crossorigin="anonymous" src="/target/eum.min.js"></script>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+    integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css"
+    integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.js"></script>
+</head>
+
+<body>
+  <nav class="navbar navbar-default">
+    <div class="container-fluid">
+      <!-- Brand and toggle get grouped for better mobile display -->
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse"
+          data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+        <a class="navbar-brand" href="#">Instana</a>
+      </div>
+
+      <!-- Collect the nav links, forms, and other content for toggling -->
+      <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+        <ul class="nav navbar-nav">
+          <li class="active"><a href="#">Repeated Injection <span class="sr-only">(current)</span></a></li>
+          <li><a href="#" id="link1">Link</a></li>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
+              aria-expanded="false">Dropdown <span class="caret"></span></a>
+            <ul class="dropdown-menu">
+              <li><a href="#">Action</a></li>
+              <li><a href="#">Another action</a></li>
+              <li><a href="#">Something else here</a></li>
+              <li role="separator" class="divider"></li>
+              <li><a href="#">Separated link</a></li>
+              <li role="separator" class="divider"></li>
+              <li><a href="#">One more separated link</a></li>
+            </ul>
+          </li>
+        </ul>
+        <form class="navbar-form navbar-left">
+          <div class="form-group">
+            <input type="text" class="form-control" placeholder="Search" id="searchInput">
+          </div>
+          <button type="button" class="btn btn-default" id="searchButton">search</button>
+        </form>
+        <ul class="nav navbar-nav navbar-right">
+          <li><a href="#">...</a></li>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
+              aria-expanded="false">Dropdown <span class="caret"></span></a>
+            <ul class="dropdown-menu">
+              <li><a href="#">Action</a></li>
+              <li><a href="#">Another action</a></li>
+              <li><a href="#">Something else here</a></li>
+              <li role="separator" class="divider"></li>
+              <li><a href="#">Separated link</a></li>
+            </ul>
+          </li>
+        </ul>
+      </div><!-- /.navbar-collapse -->
+    </div><!-- /.container-fluid -->
+  </nav>
+
+  <div class="jumbotron" id="resultwrap">
+    <div class="media">
+      <div class="media-body">
+        <h2 class="media-heading" id="page1_result">Page 1</h4>
+      </div>
+    </div>
+  </div>
+
+
+  <script>
+    $.ajax({
+      url: '/ajax' + '?r=11&cacheBust=' + (new Date()).getTime(),
+      success: function (result) {
+        $('#page1_result').text("Page 1 - " + result);
+      }
+    });
+  </script>
+
+</body>
+
+
+<!-- ############################## -->
+
+
+<head>
+  <meta charset="UTF-8">
+  <title>Page 2</title>
+
+  <script src="/e2e/initializer.js"></script>
+  <script>
+    eum('webvitalsInCustomEvent', true);
+    eum('key', 'key2');
+
+    eum('reportEvent', 'myTestEvent2', {
+      duration: 22,
+      error: new Error('Testing 22'),
+      componentStack: 'a component stack 2'
+    });
+  </script>
+  <script crossorigin="anonymous" src="/target/eum.min.js"></script>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+    integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css"
+    integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.js"></script>
+</head>
+
+<body>
+  <nav class="navbar navbar-default">
+    <div class="container-fluid">
+      <!-- Brand and toggle get grouped for better mobile display -->
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse"
+          data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+        <a class="navbar-brand" href="#">Instana</a>
+      </div>
+
+      <!-- Collect the nav links, forms, and other content for toggling -->
+      <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+        <ul class="nav navbar-nav">
+          <li class="active"><a href="#">Repeated Injection <span class="sr-only">(current)</span></a></li>
+          <li><a href="#" id="link1">Link</a></li>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
+              aria-expanded="false">Dropdown <span class="caret"></span></a>
+            <ul class="dropdown-menu">
+              <li><a href="#">Action</a></li>
+              <li><a href="#">Another action</a></li>
+              <li><a href="#">Something else here</a></li>
+              <li role="separator" class="divider"></li>
+              <li><a href="#">Separated link</a></li>
+              <li role="separator" class="divider"></li>
+              <li><a href="#">One more separated link</a></li>
+            </ul>
+          </li>
+        </ul>
+        <form class="navbar-form navbar-left">
+          <div class="form-group">
+            <input type="text" class="form-control" placeholder="Search" id="searchInput">
+          </div>
+          <button type="button" class="btn btn-default" id="searchButton">search</button>
+        </form>
+        <ul class="nav navbar-nav navbar-right">
+          <li><a href="#">...</a></li>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
+              aria-expanded="false">Dropdown <span class="caret"></span></a>
+            <ul class="dropdown-menu">
+              <li><a href="#">Action</a></li>
+              <li><a href="#">Another action</a></li>
+              <li><a href="#">Something else here</a></li>
+              <li role="separator" class="divider"></li>
+              <li><a href="#">Separated link</a></li>
+            </ul>
+          </li>
+        </ul>
+      </div><!-- /.navbar-collapse -->
+    </div><!-- /.container-fluid -->
+  </nav>
+
+  <div class="jumbotron" id="resultwrap">
+    <div class="media">
+      <div class="media-body">
+        <h2 class="media-heading" id="page2_result">Page 2</h4>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    $.ajax({
+      url: '/ajax' + '?r=22&cacheBust=' + (new Date()).getTime(),
+      success: function (result) {
+        $('#page2_result').text("Page 2 - " + result);
+      }
+    });
+  </script>
+
+</body>
+
+
+</html>

--- a/test/e2e/13_repeatedInjection/repeatedInjection.spec.js
+++ b/test/e2e/13_repeatedInjection/repeatedInjection.spec.js
@@ -1,0 +1,57 @@
+const {registerTestServerHooks, getE2ETestBaseUrl, getBeacons} = require('../../server/controls');
+const {registerBaseHooks} = require('../base');
+const {retry, expectOneMatching} = require('../../util');
+
+const cexpect = require('chai').expect;
+
+describe('13_repeatedInjection', () => {
+  registerTestServerHooks();
+  registerBaseHooks();
+
+  describe('repeatedInjection', () => {
+    beforeEach(() => {
+      browser.get(getE2ETestBaseUrl('13_repeatedInjection/repeatedInjection'));
+    });
+
+    fit('must report beacons with different key', () => {
+      return retry(() => {
+        return getBeacons().then(beacons => {
+          const pageLoadBeacon = expectOneMatching(beacons, beacon => {
+            cexpect(beacon.ty).to.equal('pl');
+            cexpect(beacon.k).to.equal('key2');
+          });
+
+          expectOneMatching(beacons, beacon => {
+            cexpect(beacon.ty).to.equal('cus');
+            cexpect(beacon.ts).to.be.a('string');
+            cexpect(beacon.n).to.equal('myTestEvent1');
+            cexpect(beacon.k).to.equal('key1');
+            cexpect(beacon.pl).to.equal(pageLoadBeacon.t);
+          });
+
+          expectOneMatching(beacons, beacon => {
+            cexpect(beacon.ty).to.equal('cus');
+            cexpect(beacon.ts).to.be.a('string');
+            cexpect(beacon.n).to.equal('myTestEvent2');
+            cexpect(beacon.k).to.equal('key2');
+            cexpect(beacon.pl).to.equal(pageLoadBeacon.t);
+          });
+
+          expectOneMatching(beacons, beacon => {
+            cexpect(beacon.ty).to.equal('xhr');
+            cexpect(beacon.u).to.match(/^http:\/\/127\.0\.0\.1:8000\/ajax\?r=11&cacheBust=\d+$/);
+            cexpect(beacon.k).to.equal('key1');
+            cexpect(beacon.pl).to.equal(pageLoadBeacon.t);
+          });
+
+          expectOneMatching(beacons, beacon => {
+            cexpect(beacon.ty).to.equal('xhr');
+            cexpect(beacon.u).to.match(/^http:\/\/127\.0\.0\.1:8000\/ajax\?r=22&cacheBust=\d+$/);
+            cexpect(beacon.k).to.equal('key2');
+            cexpect(beacon.pl).to.equal(pageLoadBeacon.t);
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/e2e/base.js
+++ b/test/e2e/base.js
@@ -1,10 +1,21 @@
+const setupBrowser = () => {
+  // we are not using Angular.js
+  browser.waitForAngularEnabled(false);
+};
+
+exports.restartBrowser = () => {
+  browser.restartSync();
+  setupBrowser();
+};
+
 exports.registerBaseHooks = () => {
   beforeEach(() => {
-    // we are not using Angular.js
-    browser.ignoreSynchronization = true;
+    setupBrowser();
   });
 
   afterEach(async () => {
+    setupBrowser();
+
     // Wait until the page is disposed to ensure that we don't have any
     // more beacons that are in flight before the next test starts.
     await browser.get('about:blank');
@@ -18,20 +29,21 @@ exports.exportCapabilities = exporter => {
 };
 
 exports.whenConfigMatches = (predicate, fn) => {
-  return browser.getProcessedConfig()
-    .then(config => {
-      if (predicate(config)) {
-        return fn(config);
-      }
+  return browser.getProcessedConfig().then(config => {
+    if (predicate(config)) {
+      return fn(config);
+    }
 
-      return true;
-    });
+    return true;
+  });
 };
 
-exports.hasResourceTimingSupport = (capabilities) => {
+exports.hasResourceTimingSupport = capabilities => {
   const version = Number(capabilities.version);
-  return (capabilities.browserName !== 'internet explorer' && capabilities.browserName !== 'safari') ||
-    (capabilities.browserName === 'internet explorer' && version >= 10);
+  return (
+    (capabilities.browserName !== 'internet explorer' && capabilities.browserName !== 'safari') ||
+    (capabilities.browserName === 'internet explorer' && version >= 10)
+  );
 };
 
 exports.hasPerformanceObserverSupport = capabilities => {

--- a/test/e2e/initializer.js
+++ b/test/e2e/initializer.js
@@ -3,12 +3,7 @@
 (function() {
   window.config = getGlobalConfigObject();
 
-  (function(
-    win,
-    longGlobalName,
-    shortGlobalName,
-    globalApi
-  ) {
+  (function(win, longGlobalName, shortGlobalName, globalApi) {
     if (win[longGlobalName]) {
       return;
     }
@@ -30,6 +25,9 @@
   eum('beaconBatchingTime', 100);
   eum('maxWaitForResourceTimingsMillis', 1000);
   eum('maxMaitForPageLoadMetricsMillis', 100);
+
+  // most existing tests does not expect extra custom events
+  eum('webvitalsInCustomEvent', false);
 
   if (window.onEumLoad) {
     window.onEumLoad(eum);
@@ -61,5 +59,5 @@
     var script = document.createElement('script');
     script.src = window.config.crossOrigin + absolutePath;
     document.body.appendChild(script);
-  }
+  };
 })();

--- a/yarn.lock
+++ b/yarn.lock
@@ -8115,7 +8115,7 @@ __metadata:
     serve-index: ^1.9.1
     sinon: ^7.0.0
     uuid: ^3.0.1
-    web-vitals: 1.1.1
+    web-vitals: 1.1.2
     webdriver-manager: ^12.1.8
   languageName: unknown
   linkType: soft
@@ -9598,10 +9598,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web-vitals@npm:1.1.1":
-  version: 1.1.1
-  resolution: "web-vitals@npm:1.1.1"
-  checksum: d3caabe88577796795bfad3c24c4afe0e0b8a4fc44edd746f211cadd12b068a5cb060713f197785de454b072a29558d945de12272c90111a03f89a1c98553e89
+"web-vitals@npm:1.1.2":
+  version: 1.1.2
+  resolution: "web-vitals@npm:1.1.2"
+  checksum: 92071029089277166e11141b735831d9011e85737d32c1360034676db898ab0ca95f19041ee01904f2189ad6e711b9da6b17567e4831290a429a586c98bc573f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**WHY:**
In some case, the webvitals metrics arrive too late after the PageLoad beacon, therefore user cannot depends on these metrics to create Alerts.

**WHAT:**
Add a new command `webvitalsInCustomEvent` (false by default), when it's enabled, webvitals will be reported in extra custom events when it's available.

The naming conversion for these metrics are `instana-webvitals-CLS`, `instana-webvitals-LCP`, `instana-webvitals-FID` etc.

the `web-vitals` was also upgraded to `1.1.2` from `1.1.1`.
