### PR TITLE
Save raw webvital value to meta

### DIFF
--- a/lib/webVitals.js
+++ b/lib/webVitals.js
@@ -22,9 +22,10 @@ function reportExtraMetrics(metric: Metric) {
   // $FlowFixMe: Flow cannot detect that this is a proper usage of the function. We have to write it this way because of the Closure compiler advanced mode.
   reportCustomEvent('instana-webvitals-' + metric.name, {
     'timestamp': pageLoadStartTimestamp + Math.round(metric.value),
-    'duration': metric.value,
+    'duration': Math.round(metric.value),
     'meta': {
-      'id': metric.id
+      'id': metric.id,
+      'v': metric.value
     }
   });
 }

--- a/test/e2e/13_repeatedInjection/repeatedInjection.spec.js
+++ b/test/e2e/13_repeatedInjection/repeatedInjection.spec.js
@@ -13,7 +13,7 @@ describe('13_repeatedInjection', () => {
       browser.get(getE2ETestBaseUrl('13_repeatedInjection/repeatedInjection'));
     });
 
-    fit('must report beacons with different key', () => {
+    it('must report beacons with different key', () => {
       return retry(() => {
         return getBeacons().then(beacons => {
           const pageLoadBeacon = expectOneMatching(beacons, beacon => {


### PR DESCRIPTION
A followup fix to https://github.com/instana/weasel/pull/125, 
when webvitalsInCustomEvent is enabled, this will also add raw value into meta data.
