### PR TITLE
disable webvital tests for saucelab

### DIFF
--- a/protractor.saucelabs.config.js
+++ b/protractor.saucelabs.config.js
@@ -2,6 +2,8 @@
 
 exports.config = {
   specs: ['test/e2e/**/*.spec.js'],
+  // TODO: disable webvital tests for saucelab for now, since browsers in saucelab seems never return webvital metrics
+  exclude: ['test/e2e/12_webvitalsAsCustomEvent/*.spec.js'],
   sauceUser: process.env.SAUCE_USERNAME,
   sauceKey: process.env.SAUCE_ACCESS_KEY,
   sauceBuild: process.env.GITHUB_RUN_NUMBER,


### PR DESCRIPTION
Disable webvital related tests, since it seems browsers in saucelab will does not return webvital metrics at all.
For now we'll disable this test (recently added).